### PR TITLE
错误日志和校验参数补充

### DIFF
--- a/sermant-plugins/sermant-server-monitor/monitor-common/src/main/java/com/huawei/sermant/sample/monitor/common/collect/CollectTask.java
+++ b/sermant-plugins/sermant-server-monitor/monitor-common/src/main/java/com/huawei/sermant/sample/monitor/common/collect/CollectTask.java
@@ -16,12 +16,17 @@
 
 package com.huawei.sermant.sample.monitor.common.collect;
 
+import com.huawei.sermant.core.common.LoggerFactory;
+
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Logger;
+
+import static com.huawei.sermant.sample.monitor.common.utils.CommonUtil.getStackTrace;
 
 /**
  * 采集任务
@@ -35,6 +40,8 @@ import java.util.concurrent.atomic.AtomicReference;
  * @param <M> 采集数据类型
  */
 public class CollectTask<M> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger();
 
     private final AtomicReference<List<M>> writeBuffer;
 
@@ -79,7 +86,13 @@ public class CollectTask<M> {
     }
 
     private void doCollect() {
-        final M m = metricProvider.collect();
+        final M m;
+        try {
+            m = metricProvider.collect();
+        } catch (Exception e) {
+            LOGGER.severe(String.format("Failed to collect metric caused by: %s", getStackTrace(e)));
+            return;
+        }
         if (m == null) {
             return;
         }

--- a/sermant-plugins/sermant-server-monitor/monitor-common/src/main/java/com/huawei/sermant/sample/monitor/common/utils/CommonUtil.java
+++ b/sermant-plugins/sermant-server-monitor/monitor-common/src/main/java/com/huawei/sermant/sample/monitor/common/utils/CommonUtil.java
@@ -14,15 +14,18 @@
  * limitations under the License.
  */
 
-package com.huawei.sermant.sample.servermonitor.common;
+package com.huawei.sermant.sample.monitor.common.utils;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 
 /**
- * 计算工具类
+ * Common工具类
  */
-public class CalculateUtil {
+public class CommonUtil {
 
     private static final BigDecimal HUNDRED = new BigDecimal("100");
 
@@ -31,4 +34,26 @@ public class CalculateUtil {
             .divide(BigDecimal.valueOf(denominator), scale, RoundingMode.HALF_UP);
     }
 
+    public static String getStackTrace(Throwable t) {
+        ByteArrayOutputStream byteArrayOutputStream = null;
+        PrintStream printStream = null;
+        try {
+            byteArrayOutputStream = new ByteArrayOutputStream();
+            printStream = new PrintStream(byteArrayOutputStream);
+            t.printStackTrace(printStream);
+            byte[] bytes = byteArrayOutputStream.toByteArray();
+            return new String(bytes);
+        } finally {
+            if (printStream != null) {
+                printStream.close();
+            }
+            if (byteArrayOutputStream != null) {
+                try {
+                    byteArrayOutputStream.close();
+                } catch (IOException e) {
+                    //ignored
+                }
+            }
+        }
+    }
 }

--- a/sermant-plugins/sermant-server-monitor/server-monitor-service/src/main/java/com/huawei/sermant/sample/servermonitor/collector/CpuMetricCollector.java
+++ b/sermant-plugins/sermant-server-monitor/server-monitor-service/src/main/java/com/huawei/sermant/sample/servermonitor/collector/CpuMetricCollector.java
@@ -21,7 +21,7 @@ import com.huawei.sermant.sample.servermonitor.command.CommandExecutor;
 import com.huawei.sermant.sample.servermonitor.command.CpuCommand;
 import com.huawei.sermant.sample.servermonitor.entity.CpuMetric;
 
-import static com.huawei.sermant.sample.servermonitor.common.CalculateUtil.getPercentage;
+import static com.huawei.sermant.sample.monitor.common.utils.CommonUtil.getPercentage;
 
 /**
  * Linux CPU指标{@link CpuMetric}采集器，通过执行两次{@link CpuCommand}命令

--- a/sermant-plugins/sermant-server-monitor/server-monitor-service/src/main/java/com/huawei/sermant/sample/servermonitor/collector/DiskMetricCollector.java
+++ b/sermant-plugins/sermant-server-monitor/server-monitor-service/src/main/java/com/huawei/sermant/sample/servermonitor/collector/DiskMetricCollector.java
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import static com.huawei.sermant.sample.servermonitor.common.CalculateUtil.getPercentage;
+import static com.huawei.sermant.sample.monitor.common.utils.CommonUtil.getPercentage;
 
 /**
  * Linux disk指标{@link DiskMetric}采集器，通过执行两次{@link DiskCommand}命令
@@ -77,6 +77,9 @@ public class DiskMetricCollector {
     private final Map<String, DiskMetric> emptyResults = new HashMap<String, DiskMetric>();
 
     public DiskMetricCollector(long collectCycle) {
+        if (collectCycle <= 0) {
+            throw new IllegalArgumentException("Collect cycle must be positive.");
+        }
         this.collectCycleMills = TimeUnit.MILLISECONDS.convert(collectCycle, TimeUnit.SECONDS);
         this.multiPlyFactor = BYTES_PER_SECTOR / collectCycle;
     }

--- a/sermant-plugins/sermant-server-monitor/server-monitor-service/src/main/java/com/huawei/sermant/sample/servermonitor/collector/NetworkMetricCollector.java
+++ b/sermant-plugins/sermant-server-monitor/server-monitor-service/src/main/java/com/huawei/sermant/sample/servermonitor/collector/NetworkMetricCollector.java
@@ -46,6 +46,9 @@ public class NetworkMetricCollector {
     private NetworkCommand.NetDev lastNetDev;
 
     public NetworkMetricCollector(long collectCycle) {
+        if (collectCycle <= 0) {
+            throw new IllegalArgumentException("Collect cycle must be positive.");
+        }
         this.collectCycle = collectCycle;
         lastNetDev = CommandExecutor.execute(Command.NETWORK);
     }

--- a/sermant-plugins/sermant-server-monitor/server-monitor-service/src/main/java/com/huawei/sermant/sample/servermonitor/command/CommonMonitorCommand.java
+++ b/sermant-plugins/sermant-server-monitor/server-monitor-service/src/main/java/com/huawei/sermant/sample/servermonitor/command/CommonMonitorCommand.java
@@ -26,6 +26,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.logging.Logger;
 
+import static com.huawei.sermant.sample.monitor.common.utils.CommonUtil.getStackTrace;
+
 /**
  * 使用通用错误处理方式的{@link MonitorCommand}，即通过日志输出错误信息，当错误
  * 信息的长度超过200时，则忽略超过该长度的内容，并在日志内容结尾添加省略号。
@@ -44,7 +46,8 @@ public abstract class CommonMonitorCommand<T> implements MonitorCommand<T> {
         try {
             return IOUtils.readLines(inputStream, Charset.defaultCharset());
         } catch (IOException e) {
-            // LOG "Failed to parse input from subprocess."
+            LOGGER.severe(String.format("Failed to parse input from subprocess caused by: %s",
+                getStackTrace(e)));
         }
         return Collections.emptyList();
     }
@@ -52,7 +55,7 @@ public abstract class CommonMonitorCommand<T> implements MonitorCommand<T> {
     @Override
     public void handleError(InputStream errorStream) {
         final List<String> lines = readLines(errorStream);
-        StringBuilder outputBuilder = new StringBuilder();
+        StringBuilder outputBuilder = new StringBuilder("Subprocess error: ");
         int totalLength = 0;
         for (String line : lines) {
             int length = line.length();

--- a/sermant-plugins/sermant-server-monitor/server-monitor-service/src/main/java/com/huawei/sermant/sample/servermonitor/provider/OpenJvmMetricProvider.java
+++ b/sermant-plugins/sermant-server-monitor/server-monitor-service/src/main/java/com/huawei/sermant/sample/servermonitor/provider/OpenJvmMetricProvider.java
@@ -77,7 +77,7 @@ public class OpenJvmMetricProvider implements MetricProvider<JVMMetric> {
     @Override
     public void consume(List<JVMMetric> metrics) {
         if (metrics == null || metrics.isEmpty()) {
-            LOGGER.warning("No Oracle jvm metric was collected.");
+            LOGGER.warning("No OpenJdk jvm metric was collected.");
             return;
         }
         JVMMetricCollection collection = JVMMetricCollection.newBuilder()


### PR DESCRIPTION
【issue号/问题单号/需求单号】#15

【修改内容】1、补充日志、参数校验 2、Linux命令执行器执行方法在返回结果前增加等待错误流处理线程的逻辑

【用例描述】不涉及

【自测情况】自测通过

【影响范围】server 监控
