### PR TITLE
backend添加展示agent信息界面

### DIFF
--- a/sermant-backend/src/main/java/com/huawei/sermant/backend/common/conf/KafkaConf.java
+++ b/sermant-backend/src/main/java/com/huawei/sermant/backend/common/conf/KafkaConf.java
@@ -67,6 +67,12 @@ public class KafkaConf {
     @Value("${kafka.session.timeout.ms}")
     private String kafkaSessionTimeoutMs;
 
+    @Value("${fetch.min.bytes}")
+    private String kafkaFetchMinBytes;
+
+    @Value("${fetch.max.wait.ms}")
+    private String kafkaFetchMaxWaitMs;
+
     @Value("${kafka.key.serializer}")
     private String kafkaKeySerializer;
 

--- a/sermant-backend/src/main/java/com/huawei/sermant/backend/entity/AgentInfo.java
+++ b/sermant-backend/src/main/java/com/huawei/sermant/backend/entity/AgentInfo.java
@@ -20,6 +20,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.util.List;
+import java.util.Map;
 
 @Getter
 @Setter
@@ -33,5 +34,5 @@ public class AgentInfo {
 
     private Object heartbeatTime;
 
-    private List<PluginInfo> pluginsInfos;
+    private Map<String, String> pluginsMap;
 }

--- a/sermant-backend/src/main/java/com/huawei/sermant/backend/entity/HeartbeatEntity.java
+++ b/sermant-backend/src/main/java/com/huawei/sermant/backend/entity/HeartbeatEntity.java
@@ -1,0 +1,29 @@
+package com.huawei.sermant.backend.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class HeartbeatEntity {
+
+   private String app;
+
+   private String hostname;
+
+   private Long heartbeatVersion;
+
+   private String pluginVersion;
+
+   private Long lastHeartbeat;
+
+   private String pluginName;
+
+   private String appType;
+
+   private List<String> ip;
+
+   private String version;
+}

--- a/sermant-backend/src/main/java/com/huawei/sermant/backend/kafka/KafkaConsumerManager.java
+++ b/sermant-backend/src/main/java/com/huawei/sermant/backend/kafka/KafkaConsumerManager.java
@@ -66,6 +66,8 @@ public class KafkaConsumerManager {
         properties.put(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, conf.getKafkaAutoCommitIntervalMs());
         properties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, conf.getKafkaAutoOffsetReset());
         properties.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, conf.getKafkaSessionTimeoutMs());
+        properties.put(ConsumerConfig.FETCH_MIN_BYTES_CONFIG, conf.getKafkaFetchMinBytes());
+        properties.put(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG, conf.getKafkaFetchMaxWaitMs());
         consumer = new KafkaConsumer<String, String>(properties);
     }
 

--- a/sermant-backend/src/main/java/com/huawei/sermant/backend/server/HttpServer.java
+++ b/sermant-backend/src/main/java/com/huawei/sermant/backend/server/HttpServer.java
@@ -24,8 +24,8 @@ import com.huawei.sermant.backend.entity.AddressScope;
 import com.huawei.sermant.backend.entity.AddressType;
 import com.huawei.sermant.backend.entity.AgentInfo;
 import com.huawei.sermant.backend.entity.HeartBeatResult;
+import com.huawei.sermant.backend.entity.HeartbeatEntity;
 import com.huawei.sermant.backend.entity.MonitorItem;
-import com.huawei.sermant.backend.entity.PluginInfo;
 import com.huawei.sermant.backend.entity.Protocol;
 import com.huawei.sermant.backend.entity.PublishConfigEntity;
 import com.huawei.sermant.backend.entity.RegisterResult;
@@ -33,6 +33,7 @@ import com.huawei.sermant.backend.kafka.KafkaConsumerManager;
 import com.huawei.sermant.backend.service.dynamicconfig.DynamicConfigurationFactoryServiceImpl;
 import com.huawei.sermant.backend.service.dynamicconfig.service.DynamicConfigurationService;
 import com.huawei.sermant.backend.service.dynamicconfig.utils.LabelGroupUtils;
+import com.huawei.sermant.backend.util.DateUtil;
 import com.huawei.sermant.backend.util.RandomUtil;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -48,6 +49,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Hashtable;
+import java.util.List;
 import java.util.Map;
 
 @Component
@@ -67,8 +69,11 @@ public class HttpServer {
     private final String DEFAULT_PLUGIN_VERSION = "unknown";
     private final String SUCCESS = "success";
     private final String FAILED = "failed";
+    private final Integer DEFAULT_IP_INDEX = 0;
+    private final Integer NULL_IP_LENGTH = 0;
 
     RandomUtil RANDOM_UTIL = new RandomUtil();
+    DateUtil DATE_UTIL = new DateUtil();
     private final Integer MIN = 1;
     private final Integer MAX = 10;
 
@@ -108,25 +113,20 @@ public class HttpServer {
 
     @GetMapping("/getPluginsInfo")
     public String invokeGet() {
+        StringBuffer stringBuffer = new StringBuffer();
         ConsumerRecords<String, String> consumerRecords = getHeartbeatInfo();
-        AgentInfo agentInfo = new AgentInfo();
-        Map<String, PluginInfo> pluginCache = new HashMap<String, PluginInfo>();
-        for (ConsumerRecord<String, String> record : consumerRecords) {
-            HashMap hashMap = JSON.parseObject(record.value(), HashMap.class);
-            agentInfo.setIp(hashMap.get("ip"));
-            agentInfo.setHeartbeatTime(hashMap.get("heartbeatVersion"));
-            agentInfo.setLastHeartbeatTime(hashMap.get("lastHeartbeat"));
-            agentInfo.setVersion(hashMap.get("version"));
-            String name = (String) hashMap.getOrDefault("pluginName", DEFAULT_AGENT_NAME);
-            if (!name.equals(DEFAULT_AGENT_NAME)) {
-                PluginInfo pluginInfo = new PluginInfo();
-                pluginInfo.setName(name);
-                pluginInfo.setVersion((String) hashMap.getOrDefault("pluginVersion", DEFAULT_PLUGIN_VERSION));
-                pluginCache.put(name, pluginInfo);
-            }
+        List<AgentInfo> agentInfoList = getPluginsInfo(consumerRecords);
+        stringBuffer.append("<html>\r").append("<body>\r").append("<table border=\"1\">\r").append("<tr>\r");
+        stringBuffer.append("<td>ip</td>\r").append("<td>version</td>\r")
+                .append("<td>heartbeatTime</td>\r").append("<td>plugin</td>\r").append("</tr>\r").append("<tr>\r");
+        for (AgentInfo agentInfo : agentInfoList) {
+            stringBuffer.append(String.format("<td>%s</td>\r", agentInfo.getIp()));
+            stringBuffer.append(String.format("<td>%s</td>\r", agentInfo.getVersion()));
+            stringBuffer.append(String.format("<td>%s</td>\r", agentInfo.getHeartbeatTime()));
+            stringBuffer.append(String.format("<td>%s</td>\r", pluginMapToStr(agentInfo.getPluginsMap())));
         }
-        agentInfo.setPluginsInfos(new ArrayList<>(pluginCache.values()));
-        return JSONObject.toJSONString(agentInfo);
+        stringBuffer.append("</tr>\r").append("</table>\r").append("</body>\r").append("</html>\r");
+        return stringBuffer.toString();
     }
 
     @PostMapping("/publishConfig")
@@ -176,5 +176,41 @@ public class HttpServer {
             LOGGER.error("getHeartbeatInfo failed");
         }
         return consumerRecords;
+    }
+
+    private String pluginMapToStr(Map<String, String> map) {
+        StringBuilder result = new StringBuilder();
+        for (Map.Entry<String, String> entry : map.entrySet()) {
+            result.append("\n").append(entry.getKey()).append("-").append(entry.getValue());
+        }
+        return result.toString();
+    }
+
+    private List<AgentInfo> getPluginsInfo(ConsumerRecords<String, String> consumerRecords) {
+        Map<String, AgentInfo> agentMap = new HashMap<>();
+        for (ConsumerRecord<String, String> record : consumerRecords) {
+            HeartbeatEntity heartbeatEntity = JSON.parseObject(record.value(), HeartbeatEntity.class);
+            List<String> ips = heartbeatEntity.getIp();
+            if (ips == null || ips.size() == NULL_IP_LENGTH) {
+                continue;
+            }
+            String ip = ips.get(DEFAULT_IP_INDEX);
+            if (agentMap.get(ip) == null) {
+                AgentInfo agentInfo = new AgentInfo();
+                agentInfo.setIp(ip);
+                agentInfo.setVersion(heartbeatEntity.getVersion());
+                agentInfo.setLastHeartbeatTime(DATE_UTIL.getFormatDate(heartbeatEntity.getLastHeartbeat()));
+                agentInfo.setHeartbeatTime(DATE_UTIL.getFormatDate(heartbeatEntity.getHeartbeatVersion()));
+                agentInfo.setPluginsMap(new HashMap<String, String>());
+                agentMap.put(ips.get(DEFAULT_IP_INDEX), agentInfo);
+            }
+            if (agentMap.get(ip) != null && heartbeatEntity.getPluginName() != null) {
+                AgentInfo agentInfo = agentMap.get(ip);
+                Map<String, String> pluginMap = agentInfo.getPluginsMap();
+                pluginMap.put(heartbeatEntity.getPluginName(), heartbeatEntity.getPluginVersion());
+                agentInfo.setPluginsMap(pluginMap);
+            }
+        }
+        return new ArrayList<>(agentMap.values());
     }
 }

--- a/sermant-backend/src/main/java/com/huawei/sermant/backend/util/DateUtil.java
+++ b/sermant-backend/src/main/java/com/huawei/sermant/backend/util/DateUtil.java
@@ -1,0 +1,11 @@
+package com.huawei.sermant.backend.util;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+public class DateUtil {
+    public String getFormatDate(Long times){
+        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        return formatter.format(times);
+    }
+}

--- a/sermant-backend/src/main/resources/application.properties
+++ b/sermant-backend/src/main/resources/application.properties
@@ -8,8 +8,10 @@ kafka.value.deserializer=org.apache.kafka.common.serialization.StringDeserialize
 kafka.group.id=test
 kafka.enable.auto.commit=true
 kafka.auto.commit.interval.ms=1000
-kafka.auto.offset.reset=earliest
+kafka.auto.offset.reset=latest
 kafka.session.timeout.ms=30000
+fetch.min.bytes=1048576
+fetch.max.wait.ms=2000
 
 kafka.key.serializer=org.apache.kafka.common.serialization.StringSerializer
 kafka.value.serializer=org.apache.kafka.common.serialization.ByteArraySerializer


### PR DESCRIPTION
【issue号/问题单号/需求单号】@247

【修改内容】

backend增加agent信息展示页面，在backend运行之后，访问http://backend_ip:8900/sermant/getPluginsInfo地址获取agent信息。

【用例描述】暂不需用例

【自测情况】

1、本地检查通过
2、页面示例：
![微信图片_20211216165454](https://user-images.githubusercontent.com/50447852/146339566-4530da79-1353-4b08-bf9d-75b1e445af38.png)

【影响范围】

1、用户运行agent之后，可以通过页面查看agent心跳和插件信息