### PR TITLE
【workflow】增加自动关闭issue和pr的工作流，暂定过期时间为30天，第29天提醒，第30天关闭，每天凌晨4点执行(格林威治时间20点)

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,24 @@
+name: Auto Close Stale Issues and PRs
+
+on:
+  schedule:
+    - cron: "0 20 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4.1.0
+        with:
+          stale-issue-label: Stale
+          stale-pr-label: Stale
+          stale-issue-message: >
+            This issue seems to be **Stale**. We will close it in a few days.
+          close-issue-message: >
+            We close this issue because it hasn't been updated in a while. Remove **Stale** label if you want to reopen it.
+          stale-pr-message: >
+            This PR seems to be **Stale**. We will close it in a few days.
+          close-pr-message: >
+            We close this PR because it hasn't been updated in a while. Remove **Stale** label if you want to reopen it.
+          days-before-stale: 29
+          days-before-close: 1


### PR DESCRIPTION
【需求单号】#260

【修改内容】增加自动关闭issue和pr的工作流，暂定过期时间为30天，第29天提醒，第30天关闭，每天凌晨4点执行(格林威治时间20点)

【用例描述】不涉及

【自测情况】测试有效：
自动调度测试：https://github.com/HapThorin/Sermant/actions/runs/1600173019
调度效果测试：https://github.com/HapThorin/Sermant/pull/3
测试中发现，github schedule 延迟较大，10分钟-20分钟左右

【影响范围】github工作流