### PR TITLE
【bug】解决backned日志中文注释解析失败导致backned启动失败问题

### DIFF
--- a/sermant-backend/pom.xml
+++ b/sermant-backend/pom.xml
@@ -13,6 +13,7 @@
         <package.output.dir>${package.server.dir}/sermant</package.output.dir>
         <jdk.version>1.8</jdk.version>
         <spring.boot.version>2.5.3</spring.boot.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
【issue号/问题单号/需求单号】#262

【修改内容】删除了backend模块日志配置的中文注释

【用例描述】暂不需用例

【自测情况】1、本地检查通过

【影响范围】无