### PR TITLE
【perf】自动关闭issue和pr的工作流调整

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,28 @@
+# Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# 用于自动关闭过期issue和pr的工作流
+# 详情请参考 https://github.com/actions/stale
+#
+# @author HapThorin
+# @date 2021/12/17
+
 name: Auto Close Stale Issues and PRs
 
 on:
   schedule:
+    # UTC/GMT+08:00 -> 北京时间凌晨4点执行
     - cron: "0 20 * * *"
 
 jobs:
@@ -9,16 +30,36 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v4.1.0
+        name: Auto Close Stale Issues
         with:
+          # 为不活跃的issue添加的标签
           stale-issue-label: Stale
-          stale-pr-label: Stale
+          # issue的不活跃警告评论
           stale-issue-message: >
             This issue seems to be **Stale**. We will close it in a few days.
+          # issue的关闭评论
           close-issue-message: >
             We close this issue because it hasn't been updated in a while. Remove **Stale** label if you want to reopen it.
+          # issue不活跃判定时间，单位：天
+          days-before-issue-stale: 29
+          # issue最终关闭间隔时间，单位：天
+          days-before-issue-close: 1
+          # 每次运行处理issue条数，如果待处理的数量过多，可修改该值
+          operations-per-run: 80
+      - uses: actions/stale@v4.1.0
+        name: Auto Close Stale PRs
+        with:
+          # 为不活跃的pr添加的标签
+          stale-pr-label: Stale
+          # pr的不活跃警告评论
           stale-pr-message: >
             This PR seems to be **Stale**. We will close it in a few days.
+          # pr的关闭评论
           close-pr-message: >
             We close this PR because it hasn't been updated in a while. Remove **Stale** label if you want to reopen it.
-          days-before-stale: 29
-          days-before-close: 1
+          # pr不活跃判定时间，单位：天
+          days-before-pr-stale: 14
+          # pr最终关闭间隔时间，单位：天
+          days-before-pr-close: 1
+          # 每次运行处理pr条数，如果待处理的数量过多，可修改该值
+          operations-per-run: 30


### PR DESCRIPTION
【问题单号】#269

【修改内容】自动关闭issue和pr的工作流调整
1、现在issue和pr扫描拆分成两步
2、据统计，Sermant目前每月新建的issue数量为60+，因此，调整处理阈值为80
3、考虑到pr处理应当比issue要及时，因此把不活跃时间判定为调整为半个月，处理阈值暂使用默认值30

【用例描述】不涉及

【自测情况】不涉及

【影响范围】过期issue和pr