### PR TITLE
【Fix】KIE配置中心修复发布配置逻辑

### DIFF
--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/service/dynamicconfig/kie/client/http/DefaultHttpClient.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/service/dynamicconfig/kie/client/http/DefaultHttpClient.java
@@ -24,8 +24,11 @@ import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.config.Registry;
@@ -154,6 +157,21 @@ public class DefaultHttpClient implements com.huawei.sermant.core.service.dynami
         return execute(httpPost);
     }
 
+    @Override
+    public HttpResult doPut(String url, Map<String, Object> params) {
+        final HttpPut httpPut = new HttpPut(url);
+        beforeRequest(httpPut, null, new HashMap<>());
+        addParams(httpPut, params);
+        return execute(httpPut);
+    }
+
+    @Override
+    public HttpResult doDelete(String url) {
+        final HttpDelete httpDelete = new HttpDelete(url);
+        beforeRequest(httpDelete, null, null);
+        return execute(httpDelete);
+    }
+
     /**
      * 执行请求
      *
@@ -193,7 +211,7 @@ public class DefaultHttpClient implements com.huawei.sermant.core.service.dynami
         }
     }
 
-    private void addParams(HttpPost httpPost, Map<String, Object> params) {
+    private void addParams(HttpEntityEnclosingRequestBase httpPost, Map<String, Object> params) {
         if (params == null || params.isEmpty()) {
             return;
         }

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/service/dynamicconfig/kie/client/http/HttpClient.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/service/dynamicconfig/kie/client/http/HttpClient.java
@@ -86,4 +86,20 @@ public interface HttpClient extends Client {
      */
     HttpResult doPost(String url, Map<String, Object> params, RequestConfig requestConfig, Map<String, String> headers);
 
+    /**
+     * put请求
+     *
+     * @param url 请求地址
+     * @param params 请求参数
+     * @return HttpResult
+     */
+    HttpResult doPut(String url, Map<String, Object> params);
+
+    /**
+     * delete请求
+     *
+     * @param url 请求地址
+     * @return HttpResult
+     */
+    HttpResult doDelete(String url);
 }

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/service/dynamicconfig/kie/client/kie/KieClient.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/service/dynamicconfig/kie/client/kie/KieClient.java
@@ -22,10 +22,10 @@ import com.huawei.sermant.core.service.dynamicconfig.kie.client.ClientUrlManager
 import com.huawei.sermant.core.service.dynamicconfig.kie.client.http.HttpClient;
 import com.huawei.sermant.core.service.dynamicconfig.kie.client.http.HttpResult;
 import com.huawei.sermant.core.service.dynamicconfig.kie.config.KieDynamicConfig;
-
 import org.apache.http.HttpStatus;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -72,9 +72,9 @@ public class KieClient extends AbstractClient {
     /**
      * 查询Kie配置
      *
-     * @param request 请求体
+     * @param request         请求体
      * @param responseHandler http结果处理器
-     * @param <T> 转换后的目标类型
+     * @param <T>             转换后的目标类型
      * @return 响应结果
      */
     public <T> T queryConfigurations(KieRequest request, ResultHandler<T> responseHandler) {
@@ -98,18 +98,50 @@ public class KieClient extends AbstractClient {
     /**
      * 发布配置
      *
-     * @param key 请求键
-     * @param labels 标签
+     * @param key     请求键
+     * @param labels  标签
      * @param content 配置
      * @return 是否发布成功
      */
     public boolean publishConfig(String key, Map<String, String> labels, String content, boolean enabled) {
-        final Map<String, Object> params = new HashMap<>();
+        final Map<String, Object> params = new HashMap<String, Object>();
         params.put("key", key);
         params.put("value", content);
         params.put("labels", labels);
         params.put("status", enabled ? "enabled" : "disabled");
         final HttpResult httpResult = this.httpClient.doPost(clientUrlManager.getUrl() + kieApi, params);
+        return httpResult.getCode() == HttpStatus.SC_OK;
+    }
+
+    /**
+     * 更新配置
+     *
+     * @param keyId   key-id
+     * @param content 更新内容
+     * @param enabled 是否开启
+     * @return 是否更新成功
+     */
+    public boolean doUpdateConfig(String keyId, String content, boolean enabled) {
+        final Map<String, Object> params = new HashMap<String, Object>();
+        params.put("value", content);
+        params.put("status", enabled ? "enabled" : "disabled");
+        final HttpResult httpResult = this.httpClient.doPut(buildKeyIdUrl(keyId), params);
+        return httpResult.getCode() == HttpStatus.SC_OK;
+    }
+
+    private String buildKeyIdUrl(String keyId) {
+        return String.format(Locale.ENGLISH, "%s/%s",
+                clientUrlManager.getUrl() + kieApi.substring(0, kieApi.length() - 1) , keyId);
+    }
+
+    /**
+     * 删除方法
+     *
+     * @param keyId key编号
+     * @return 是否删除成功
+     */
+    public boolean doDeleteConfig(String keyId) {
+        final HttpResult httpResult = this.httpClient.doDelete(buildKeyIdUrl(keyId));
         return httpResult.getCode() == HttpStatus.SC_OK;
     }
 

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/service/dynamicconfig/kie/client/kie/KieListenerWrapper.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/service/dynamicconfig/kie/client/kie/KieListenerWrapper.java
@@ -17,14 +17,18 @@
 package com.huawei.sermant.core.service.dynamicconfig.kie.client.kie;
 
 import com.huawei.sermant.core.common.LoggerFactory;
+import com.huawei.sermant.core.service.dynamicconfig.common.DynamicConfigEvent;
+import com.huawei.sermant.core.service.dynamicconfig.common.DynamicConfigEventType;
+import com.huawei.sermant.core.service.dynamicconfig.common.DynamicConfigListener;
+import com.huawei.sermant.core.service.dynamicconfig.kie.constants.KieConstants;
 import com.huawei.sermant.core.service.dynamicconfig.kie.listener.KvDataHolder;
 import com.huawei.sermant.core.service.dynamicconfig.kie.listener.SubscriberManager;
-import com.huawei.sermant.core.service.dynamicconfig.common.DynamicConfigEventType;
-import com.huawei.sermant.core.service.dynamicconfig.common.DynamicConfigEvent;
-import com.huawei.sermant.core.service.dynamicconfig.common.DynamicConfigListener;
 
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Logger;
 
 /**
@@ -36,15 +40,32 @@ import java.util.logging.Logger;
 public class KieListenerWrapper {
     private static final Logger LOGGER = LoggerFactory.getLogger();
 
-    private DynamicConfigListener dynamicConfigListener;
-
-    private SubscriberManager.Task task;
-
-    private String group;
+    private final String group;
 
     private final KvDataHolder kvDataHolder;
 
+    private final KieRequest kieRequest;
+
+    private long currentVersion;
+
+    /**
+     * map<key, list<listener>>
+     * 单个key映射多个listener， 针对单个key的场景进行监听
+     */
+    private final Map<String, VersionListenerWrapper> keyListenerMap = new HashMap<>();
+
+    private SubscriberManager.Task task;
+
+    public KieListenerWrapper(String key, DynamicConfigListener dynamicConfigListener,
+                              KvDataHolder kvDataHolder, KieRequest kieRequest) {
+        this.group = kieRequest.getLabelCondition();
+        this.kvDataHolder = kvDataHolder;
+        this.kieRequest = kieRequest;
+        addKeyListener(key, dynamicConfigListener);
+    }
+
     public void notifyListener(KvDataHolder.EventDataHolder eventDataHolder) {
+        currentVersion = eventDataHolder.getVersion();
         if (!eventDataHolder.getAdded().isEmpty()) {
             // 新增事件
             notify(eventDataHolder.getAdded(), DynamicConfigEventType.CREATE);
@@ -61,50 +82,93 @@ public class KieListenerWrapper {
 
     private void notify(Map<String, String> configData, DynamicConfigEventType dynamicConfigEventType) {
         for (Map.Entry<String, String> entry : configData.entrySet()) {
-            try {
-                notifyEvent(entry.getKey(), entry.getValue(), dynamicConfigEventType);
-            } catch (Throwable ex) {
-                LOGGER.warning(String.format(Locale.ENGLISH, "Process config data failed, key: [%s], group: [%s]",
-                        entry.getKey(), this.group));
-            }
+            // 通知单个key监听器
+            notifyEvent(entry.getKey(), entry.getValue(), dynamicConfigEventType);
+            // 通知该Group的监听器做更新
+            notifyEvent(KieConstants.DEFAULT_GROUP_KEY, entry.getValue(), dynamicConfigEventType);
         }
     }
 
     private void notifyEvent(String key, String value, DynamicConfigEventType eventType) {
+        final VersionListenerWrapper versionListenerWrapper = keyListenerMap.get(key);
+        if (versionListenerWrapper == null) {
+            return;
+        }
         switch (eventType) {
             case CREATE:
-                dynamicConfigListener.process(DynamicConfigEvent.createEvent(key, this.group, value));
+                processAllListeners(DynamicConfigEvent.createEvent(key, this.group, value), versionListenerWrapper);
                 break;
             case MODIFY:
-                dynamicConfigListener.process(DynamicConfigEvent.modifyEvent(key, this.group, value));
+                processAllListeners(DynamicConfigEvent.modifyEvent(key, this.group, value), versionListenerWrapper);
                 break;
             case DELETE:
-                dynamicConfigListener.process(DynamicConfigEvent.deleteEvent(key, this.group, value));
+                processAllListeners(DynamicConfigEvent.deleteEvent(key, this.group, value), versionListenerWrapper);
                 break;
             default:
                 LOGGER.warning(String.format(Locale.ENGLISH, "Event type [%s] is invalid. ", eventType));
         }
     }
 
-    public KieListenerWrapper(DynamicConfigListener dynamicConfigListener, SubscriberManager.Task task,
-                              KvDataHolder kvDataHolder) {
-        this.dynamicConfigListener = dynamicConfigListener;
-        this.task = task;
-        this.kvDataHolder = kvDataHolder;
+    private void processAllListeners(DynamicConfigEvent event, VersionListenerWrapper versionListenerWrapper) {
+        if (versionListenerWrapper.listeners != null) {
+            for (VersionListener versionListener : versionListenerWrapper.listeners) {
+                try {
+                    if (versionListener.version > currentVersion) {
+                        // 已通知的listener不再通知, 避免针对同一个group的多个不同key进行多次重复通知
+                        return;
+                    }
+                    versionListener.listener.process(event);
+                    versionListener.version = currentVersion;
+                } catch (Exception ex) {
+                    LOGGER.warning(String.format(Locale.ENGLISH, "Process config data failed, key: [%s], group: [%s]",
+                            event.getKey(), this.group));
+                }
+            }
+        }
     }
 
-    public KieListenerWrapper(String group, DynamicConfigListener dynamicConfigListener, KvDataHolder kvDataHolder) {
-        this.group = group;
-        this.dynamicConfigListener = dynamicConfigListener;
-        this.kvDataHolder = kvDataHolder;
+    /**
+     * 添加key监听器
+     *
+     * @param key                   键
+     * @param dynamicConfigListener 监听器
+     */
+    public void addKeyListener(String key, DynamicConfigListener dynamicConfigListener) {
+        VersionListenerWrapper versionListenerWrapper = keyListenerMap.get(key);
+        if (versionListenerWrapper == null) {
+            versionListenerWrapper = new VersionListenerWrapper();
+        }
+        versionListenerWrapper.addListener(dynamicConfigListener);
+        keyListenerMap.put(key, versionListenerWrapper);
     }
 
-    public DynamicConfigListener getConfigurationListener() {
-        return dynamicConfigListener;
+    /**
+     * 移除key监听器
+     *
+     * @param key      键
+     * @param listener 监听器
+     * @return 是否移除成功
+     */
+    public boolean removeKeyListener(String key, DynamicConfigListener listener) {
+        final VersionListenerWrapper versionListenerWrapper = keyListenerMap.get(key);
+        if (versionListenerWrapper == null) {
+            return false;
+        }
+        return versionListenerWrapper.removeListener(listener);
     }
 
-    public void setConfigurationListener(DynamicConfigListener dynamicConfigListener) {
-        this.dynamicConfigListener = dynamicConfigListener;
+    /**
+     * 当前分组的所有监听器是否全部清空
+     *
+     * @return 为空 返回 true
+     */
+    public boolean isEmpty() {
+        for (VersionListenerWrapper wrap : keyListenerMap.values()) {
+            if (!wrap.listeners.isEmpty()) {
+                return false;
+            }
+        }
+        return true;
     }
 
     public SubscriberManager.Task getTask() {
@@ -117,5 +181,58 @@ public class KieListenerWrapper {
 
     public KvDataHolder getKvDataHolder() {
         return kvDataHolder;
+    }
+
+    public KieRequest getKieRequest() {
+        return kieRequest;
+    }
+
+    static class VersionListenerWrapper {
+        Set<VersionListener> listeners;
+
+        VersionListenerWrapper() {
+            listeners = new HashSet<>();
+        }
+
+        void addListener(DynamicConfigListener listener) {
+            listeners.add(new VersionListener(-1L, listener));
+        }
+
+        boolean removeListener(DynamicConfigListener listener) {
+            // VersionListener基于listener移除
+            return listeners.remove(new VersionListener(-1L, listener));
+        }
+    }
+
+    static class VersionListener {
+        DynamicConfigListener listener;
+
+        /**
+         * 已通知的版本号, 基于KIE数据版本号，即revision
+         */
+        long version;
+
+        VersionListener(long version, DynamicConfigListener listener) {
+            this.listener = listener;
+            this.version = version;
+        }
+
+        @Override
+        public boolean equals(Object target) {
+            if (this == target) {
+                return true;
+            }
+            if (target == null || getClass() != target.getClass()) {
+                return false;
+            }
+            VersionListener that = (VersionListener) target;
+
+            return listener != null ? listener.equals(that.listener) : that.listener == null;
+        }
+
+        @Override
+        public int hashCode() {
+            return listener != null ? listener.hashCode() : 0;
+        }
     }
 }

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/service/dynamicconfig/kie/constants/KieConstants.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/service/dynamicconfig/kie/constants/KieConstants.java
@@ -24,17 +24,7 @@ package com.huawei.sermant.core.service.dynamicconfig.kie.constants;
  */
 public class KieConstants {
     /**
-     * 核心线程数
+     * 默认groupKey
      */
-    public static final int CORE_THREAD_SIZE = 1;
-
-    /**
-     * 最大线程数
-     */
-    public static final int MAX_THREAD_SIZE = 3;
-
-    /**
-     * 队列长度
-     */
-    public static final int QUEUE_SIZE = 100;
+    public static final String DEFAULT_GROUP_KEY = "_DEFAULT_GROUP_KEY";
 }

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/service/dynamicconfig/kie/listener/SubscriberManager.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/service/dynamicconfig/kie/listener/SubscriberManager.java
@@ -27,17 +27,17 @@ import com.huawei.sermant.core.lubanops.integration.utils.APMThreadFactory;
 import com.huawei.sermant.core.service.dynamicconfig.common.DynamicConfigListener;
 import com.huawei.sermant.core.service.dynamicconfig.kie.client.ClientUrlManager;
 import com.huawei.sermant.core.service.dynamicconfig.kie.client.kie.KieClient;
+import com.huawei.sermant.core.service.dynamicconfig.kie.client.kie.KieConfigEntity;
 import com.huawei.sermant.core.service.dynamicconfig.kie.client.kie.KieListenerWrapper;
 import com.huawei.sermant.core.service.dynamicconfig.kie.client.kie.KieRequest;
 import com.huawei.sermant.core.service.dynamicconfig.kie.client.kie.KieResponse;
 import com.huawei.sermant.core.service.dynamicconfig.kie.client.kie.KieSubscriber;
+import com.huawei.sermant.core.service.dynamicconfig.kie.client.kie.ResultHandler;
+import com.huawei.sermant.core.service.dynamicconfig.kie.constants.KieConstants;
 import com.huawei.sermant.core.service.dynamicconfig.utils.LabelGroupUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.config.RequestConfig;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -96,14 +96,19 @@ public class SubscriberManager {
     private final AtomicInteger curLongConnectionRequestCount = new AtomicInteger(0);
 
     /**
-     * map<监听键, 监听该键的监听器列表>
+     * map<监听键, 监听该键的监听器列表>  一个group，仅有一个KieListenerWrapper
      */
-    private final Map<KieSubscriber, List<KieListenerWrapper>> listenerMap = new ConcurrentHashMap<KieSubscriber, List<KieListenerWrapper>>();
+    private final Map<KieRequest, KieListenerWrapper> listenerMap = new ConcurrentHashMap<KieRequest, KieListenerWrapper>();
 
     /**
      * kie客户端
      */
     private final KieClient kieClient;
+
+    /**
+     * 接收所有数据，不过滤disabled的数据
+     */
+    private final ResultHandler<KieResponse> receiveAllDataHandler = new ResultHandler.DefaultResultHandler(false);
 
     /**
      * 订阅执行器
@@ -133,8 +138,27 @@ public class SubscriberManager {
      */
     public boolean addGroupListener(String group, DynamicConfigListener listener, boolean ifNotify) {
         try {
-            return subscribe(new KieRequest().setLabelCondition(LabelGroupUtils.getLabelCondition(group)).setWait(WAIT),
-                    listener, ifNotify);
+            return subscribe(KieConstants.DEFAULT_GROUP_KEY, new KieRequest().setLabelCondition(
+                    LabelGroupUtils.getLabelCondition(group)).setWait(WAIT), listener, ifNotify);
+        } catch (Exception ex) {
+            LOGGER.warning(String.format(Locale.ENGLISH, "Add group listener failed, %s", ex.getMessage()));
+            return false;
+        }
+    }
+
+    /**
+     * 添加单个key监听器
+     *
+     * @param key      键
+     * @param group    标签组
+     * @param listener 监听器
+     * @param ifNotify 是否在第一次添加时，将所有数据查询返回给调用者
+     * @return 是否添加成功
+     */
+    public boolean addConfigListener(String key, String group, DynamicConfigListener listener, boolean ifNotify) {
+        try {
+            return subscribe(key, new KieRequest().setLabelCondition(
+                    LabelGroupUtils.getLabelCondition(group)).setWait(WAIT), listener, ifNotify);
         } catch (Exception ex) {
             LOGGER.warning(String.format(Locale.ENGLISH, "Add group listener failed, %s", ex.getMessage()));
             return false;
@@ -150,8 +174,8 @@ public class SubscriberManager {
      */
     public boolean removeGroupListener(String group, DynamicConfigListener listener) {
         try {
-            return unSubscribe(new KieRequest().setLabelCondition(LabelGroupUtils.getLabelCondition(group)).setWait(WAIT),
-                    listener);
+            return unSubscribe(KieConstants.DEFAULT_GROUP_KEY, new KieRequest().setLabelCondition(
+                    LabelGroupUtils.getLabelCondition(group)).setWait(WAIT), listener);
         } catch (Exception ex) {
             LOGGER.warning(String.format(Locale.ENGLISH, "Removed group listener failed, %s", ex.getMessage()));
             return false;
@@ -159,7 +183,7 @@ public class SubscriberManager {
     }
 
     /**
-     * 发布配置
+     * 发布配置, 若配置已存在则转为更新配置
      *
      * @param key     配置键
      * @param group   分组
@@ -167,11 +191,68 @@ public class SubscriberManager {
      * @return 是否发布成功
      */
     public boolean publishConfig(String key, String group, String content) {
-        if (StringUtils.isEmpty(key)) {
+        final String keyId = getKeyId(key, group);
+        if (keyId == null) {
+            // 无该配置 执行新增操作
+            final Map<String, String> labels = LabelGroupUtils.resolveGroupLabels(group);
+            return kieClient.publishConfig(key, labels, content, true);
+        } else {
+            return kieClient.doUpdateConfig(keyId, content, true);
+        }
+    }
+
+    /**
+     * 移除配置
+     *
+     * @param key   键名称
+     * @param group 分组
+     * @return 是否删除成功
+     */
+    public boolean removeConfig(String key, String group) {
+        final String keyId = getKeyId(key, group);
+        if (keyId == null) {
             return false;
         }
+        return kieClient.doDeleteConfig(keyId);
+    }
+
+    /**
+     * 获取key_id
+     *
+     * @param key   键
+     * @param group 组
+     * @return key_id, 若不存在则返回null
+     */
+    private String getKeyId(String key, String group) {
+        final KieResponse kieResponse = queryConfigurations(null, LabelGroupUtils.getLabelCondition(group), false);
+        if (kieResponse == null || kieResponse.getData() == null) {
+            return null;
+        }
         final Map<String, String> labels = LabelGroupUtils.resolveGroupLabels(group);
-        return kieClient.publishConfig(key, labels, content, true);
+        for (KieConfigEntity entity : kieResponse.getData()) {
+            if (isSameKey(entity, key, labels)) {
+                return entity.getId();
+            }
+        }
+        return null;
+    }
+
+    private boolean isSameKey(KieConfigEntity entity, String targetKey, Map<String, String> targetLabels) {
+        if (!StringUtils.equals(entity.getKey(), targetKey)) {
+            return false;
+        }
+        // 比较标签是否相同
+        final Map<String, String> sourceLabels = entity.getLabels();
+        if (sourceLabels == null || (sourceLabels.size() != targetLabels.size())) {
+            return false;
+        }
+        for (Map.Entry<String, String> entry : sourceLabels.entrySet()) {
+            final String labelValue = targetLabels.get(entry.getKey());
+            if (!StringUtils.equals(labelValue, entry.getValue())) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**
@@ -179,13 +260,33 @@ public class SubscriberManager {
      *
      * @param kieRequest            请求
      * @param dynamicConfigListener 监听器
-     * @param ifNotify 是否在第一次添加时，将所有数据查询返回给调用者
+     * @param ifNotify              是否在第一次添加时，将所有数据查询返回给调用者
      */
-    public boolean subscribe(KieRequest kieRequest, DynamicConfigListener dynamicConfigListener, boolean ifNotify) {
+    public boolean subscribe(String key, KieRequest kieRequest, DynamicConfigListener dynamicConfigListener, boolean ifNotify) {
+        final KieListenerWrapper oldWrapper = listenerMap.get(kieRequest);
+        if (oldWrapper == null) {
+            return firstSubscribeForGroup(key, kieRequest, dynamicConfigListener, ifNotify);
+        } else {
+            oldWrapper.addKeyListener(key, dynamicConfigListener);
+            tryNotify(oldWrapper.getKieRequest(), oldWrapper, ifNotify);
+            return true;
+        }
+    }
+
+    private void tryNotify(KieRequest request, KieListenerWrapper wrapper, boolean ifNotify) {
+        if (ifNotify) {
+            firstRequest(request, wrapper);
+        }
+    }
+
+    private boolean firstSubscribeForGroup(String key,
+                                           KieRequest kieRequest,
+                                           DynamicConfigListener dynamicConfigListener,
+                                           boolean ifNotify) {
         final KieSubscriber kieSubscriber = new KieSubscriber(kieRequest);
         Task task;
-        KieListenerWrapper kieListenerWrapper = new KieListenerWrapper(kieRequest.getLabelCondition(),
-                dynamicConfigListener, new KvDataHolder());
+        KieListenerWrapper kieListenerWrapper = new KieListenerWrapper(key,
+                dynamicConfigListener, new KvDataHolder(), kieRequest);
         if (!kieSubscriber.isLongConnectionRequest()) {
             task = new ShortTimerTask(kieSubscriber, kieListenerWrapper);
         } else {
@@ -198,16 +299,9 @@ public class SubscriberManager {
             buildRequestConfig(kieRequest);
             task = new LoopPullTask(kieSubscriber, kieListenerWrapper);
         }
-        if (ifNotify) {
-            firstRequest(kieRequest, kieListenerWrapper);
-        }
-        List<KieListenerWrapper> configurationListeners = listenerMap.get(kieSubscriber);
-        if (configurationListeners == null) {
-            configurationListeners = new ArrayList<KieListenerWrapper>();
-        }
         kieListenerWrapper.setTask(task);
-        configurationListeners.add(kieListenerWrapper);
-        listenerMap.put(kieSubscriber, configurationListeners);
+        listenerMap.put(kieRequest, kieListenerWrapper);
+        tryNotify(kieRequest, kieListenerWrapper, ifNotify);
         executeTask(task);
         return true;
     }
@@ -229,9 +323,9 @@ public class SubscriberManager {
      */
     public void firstRequest(KieRequest kieRequest, KieListenerWrapper kieListenerWrapper) {
         try {
-            KieResponse kieResponse = queryConfigurations(kieRequest.getRevision(), kieRequest.getLabelCondition());
+            KieResponse kieResponse = queryConfigurations(null, kieRequest.getLabelCondition());
             if (kieResponse != null && kieResponse.isChanged()) {
-                tryPublishEvent(kieResponse, kieListenerWrapper);
+                tryPublishEvent(kieResponse, kieListenerWrapper, true);
                 kieRequest.setRevision(kieResponse.getRevision());
             }
         } catch (Exception ex) {
@@ -247,8 +341,23 @@ public class SubscriberManager {
      * @return kv配置
      */
     public KieResponse queryConfigurations(String revision, String label) {
+        return queryConfigurations(revision, label, true);
+    }
+
+    /**
+     * 单独查询配置
+     *
+     * @param revision 版本
+     * @param label    关联标签组
+     * @param onlyEnabled 是否仅可用status=enabled
+     * @return kv配置
+     */
+    public KieResponse queryConfigurations(String revision, String label, boolean onlyEnabled) {
         final KieRequest cloneRequest = new KieRequest().setRevision(revision).setLabelCondition(label);
-        return kieClient.queryConfigurations(cloneRequest);
+        if (onlyEnabled) {
+            return kieClient.queryConfigurations(cloneRequest);
+        }
+        return kieClient.queryConfigurations(cloneRequest, receiveAllDataHandler);
     }
 
     /**
@@ -256,25 +365,22 @@ public class SubscriberManager {
      *
      * @param kieRequest 请求体
      */
-    public boolean unSubscribe(KieRequest kieRequest, DynamicConfigListener dynamicConfigListener) {
-        for (Map.Entry<KieSubscriber, List<KieListenerWrapper>> next : listenerMap.entrySet()) {
-            if (!next.getKey().getKieRequest().equals(kieRequest)) {
+    public boolean unSubscribe(String key, KieRequest kieRequest, DynamicConfigListener dynamicConfigListener) {
+        for (Map.Entry<KieRequest, KieListenerWrapper> next : listenerMap.entrySet()) {
+            if (!next.getKey().equals(kieRequest)) {
                 continue;
             }
             if (dynamicConfigListener == null) {
                 listenerMap.remove(next.getKey());
                 return true;
             } else {
-                final Iterator<KieListenerWrapper> iterator = next.getValue().iterator();
-                while (iterator.hasNext()) {
-                    final KieListenerWrapper listenerWrapper = iterator.next();
-                    if (listenerWrapper.getConfigurationListener() == dynamicConfigListener) {
-                        iterator.remove();
-                        listenerWrapper.getTask().stop();
-                        LOGGER.fine(String.format(Locale.ENGLISH, "%s has been stopped!",
-                                dynamicConfigListener.getClass().getName()));
-                        return true;
+                final KieListenerWrapper wrapper = next.getValue();
+                if (wrapper.removeKeyListener(key, dynamicConfigListener)) {
+                    if (wrapper.isEmpty()) {
+                        // 若监听器均已清空，则停止改标签组的任务
+                        wrapper.getTask().stop();
                     }
+                    return true;
                 }
             }
         }
@@ -315,10 +421,10 @@ public class SubscriberManager {
         }
     }
 
-    private void tryPublishEvent(KieResponse kieResponse, KieListenerWrapper kieListenerWrapper) {
+    private void tryPublishEvent(KieResponse kieResponse, KieListenerWrapper kieListenerWrapper, boolean isFirst) {
         final KvDataHolder kvDataHolder = kieListenerWrapper.getKvDataHolder();
-        final KvDataHolder.EventDataHolder eventDataHolder = kvDataHolder.analyzeLatestData(kieResponse);
-        if (eventDataHolder.isChanged()) {
+        final KvDataHolder.EventDataHolder eventDataHolder = kvDataHolder.analyzeLatestData(kieResponse, isFirst);
+        if (eventDataHolder.isChanged() || isFirst) {
             kieListenerWrapper.notifyListener(eventDataHolder);
         }
     }
@@ -400,7 +506,7 @@ public class SubscriberManager {
         public void executeInner() {
             final KieResponse kieResponse = kieClient.queryConfigurations(kieSubscriber.getKieRequest());
             if (kieResponse != null && kieResponse.isChanged()) {
-                tryPublishEvent(kieResponse, kieListenerWrapper);
+                tryPublishEvent(kieResponse, kieListenerWrapper, false);
                 kieSubscriber.getKieRequest().setRevision(kieResponse.getRevision());
             }
         }
@@ -428,7 +534,7 @@ public class SubscriberManager {
             try {
                 final KieResponse kieResponse = kieClient.queryConfigurations(kieSubscriber.getKieRequest());
                 if (kieResponse != null && kieResponse.isChanged()) {
-                    tryPublishEvent(kieResponse, kieListenerWrapper);
+                    tryPublishEvent(kieResponse, kieListenerWrapper, false);
                     kieSubscriber.getKieRequest().setRevision(kieResponse.getRevision());
                 }
                 // 间隔一段时间拉取，减轻服务压力;

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/service/dynamicconfig/utils/LabelGroupUtils.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/service/dynamicconfig/utils/LabelGroupUtils.java
@@ -103,7 +103,8 @@ public class LabelGroupUtils {
             return result;
         }
         if (!isLabelGroup(group)) {
-            return result;
+            // 如果非group标签（ZK配置中心场景适配），则为该group创建标签
+            group = LabelGroupUtils.createLabelGroup(Collections.singletonMap("GROUP", group));
         }
         try {
             final String decode = URLDecoder.decode(group, "UTF-8");

--- a/sermant-agentcore/sermant-agentcore-core/src/test/java/com/huawei/sermant/core/service/dynamicconfig/BaseTest.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/test/java/com/huawei/sermant/core/service/dynamicconfig/BaseTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2021-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.sermant.core.service.dynamicconfig;
+
+import com.huawei.sermant.core.common.CommonConstant;
+import com.huawei.sermant.core.common.LoggerFactory;
+import com.huawei.sermant.core.config.ConfigManager;
+import com.huawei.sermant.core.config.common.BaseConfig;
+import com.huawei.sermant.core.lubanops.bootstrap.config.AgentConfigManager;
+import com.huawei.sermant.core.service.ServiceManager;
+import com.huawei.sermant.core.service.dynamicconfig.config.DynamicConfig;
+import com.huawei.sermant.core.service.dynamicconfig.kie.config.KieDynamicConfig;
+import com.huawei.sermant.core.service.heartbeat.HeartbeatConfig;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.net.URL;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * 测试基础化基类
+ *
+ * @author zhouss
+ * @since 2021-12-25
+ */
+public class BaseTest {
+    protected static Map<String, BaseConfig> configManagerMap;
+
+    protected static ClassLoader currentClassLoader;
+
+    @BeforeClass
+    public static void init() throws IllegalAccessException, NoSuchFieldException, ClassNotFoundException {
+        currentClassLoader = Thread.currentThread().getContextClassLoader();
+        final Class<?> configManagerClass = currentClassLoader.loadClass(AgentConfigManager.class.getName());
+        final Field nettyServerPort = configManagerClass.getDeclaredField("nettyServerPort");
+        setFieldValue(nettyServerPort, "6888", null);
+
+        final Field nettyServerIp = configManagerClass.getDeclaredField("nettyServerIp");
+        setFieldValue(nettyServerIp, "127.0.0.1", null);
+
+        final Class<?> aClass = currentClassLoader.loadClass(ConfigManager.class.getName());
+        final Field configMap = aClass.getDeclaredField("CONFIG_MAP");
+        configMap.setAccessible(true);
+        removeFinalModify(configMap);
+
+        configManagerMap = (Map<String, BaseConfig>) configMap.get(null);
+        configManagerMap.put("heartbeat", new HeartbeatConfig());
+        configManagerMap.put("dynamic.config", new DynamicConfig());
+        configManagerMap.put("kie.dynamic.config", new KieDynamicConfig());
+        configMap.set(null, configManagerMap);
+        ServiceManager.initServices();
+
+        final URL logbackSettingURL = BaseTest.class.getResource("/logback-test.xml");
+        Assert.assertNotNull(logbackSettingURL);
+        LoggerFactory.init(Collections.<String, Object>singletonMap(CommonConstant.LOG_SETTING_FILE_KEY, logbackSettingURL.getPath()));
+    }
+
+    /**
+     * 移除final修饰符
+     *
+     * @param field 字段
+     * @throws NoSuchFieldException 无该字段抛出
+     * @throws IllegalAccessException 无法拿到该字段抛出
+     */
+    protected static void removeFinalModify(Field field) throws NoSuchFieldException, IllegalAccessException {
+        Field modifiersField = Field.class.getDeclaredField("modifiers");
+        modifiersField.setAccessible(true);
+        modifiersField.setInt(field,field.getModifiers()&~Modifier.FINAL);
+    }
+
+    /**
+     * 反射设置字段值
+     *
+     * @param field 字段
+     * @param value 值
+     * @param target 目前类  静态属性为null
+     * @throws IllegalAccessException 找不到抛出异常
+     */
+    protected static void setFieldValue(Field field, Object value, Object target) throws IllegalAccessException {
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}

--- a/sermant-agentcore/sermant-agentcore-core/src/test/java/com/huawei/sermant/core/service/dynamicconfig/KieDynamicConfigServiceTest.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/test/java/com/huawei/sermant/core/service/dynamicconfig/KieDynamicConfigServiceTest.java
@@ -18,7 +18,11 @@ package com.huawei.sermant.core.service.dynamicconfig;
 
 import java.net.URL;
 import java.util.Collections;
+import java.util.Locale;
 
+import com.huawei.sermant.core.config.ConfigManager;
+import com.huawei.sermant.core.service.ServiceManager;
+import com.huawei.sermant.core.service.dynamicconfig.config.DynamicConfig;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -36,13 +40,7 @@ import com.huawei.sermant.core.service.dynamicconfig.utils.LabelGroupUtils;
  * @author zhouss
  * @since 2021-11-22
  */
-public class KieDynamicConfigServiceTest {
-    @Before
-    public void before() {
-        final URL logbackSettingURL = getClass().getResource("/logback-test.xml");
-        Assert.assertNotNull(logbackSettingURL);
-        LoggerFactory.init(Collections.singletonMap(CommonConstant.LOG_SETTING_FILE_KEY, logbackSettingURL.getPath()));
-    }
+public class KieDynamicConfigServiceTest extends BaseTest {
 
     @Test
     public void testListener() {
@@ -57,5 +55,30 @@ public class KieDynamicConfigServiceTest {
         };
         subscriberManager.addGroupListener(group, dynamicConfigListener, true);
         Assert.assertTrue(subscriberManager.removeGroupListener(group, dynamicConfigListener));
+    }
+
+    @Test
+    public void testAddListener() {
+        final DynamicConfigService service = ServiceManager.getService(DynamicConfigService.class);
+        service.addConfigListener("rule", "groupTest=aa", new DynamicConfigListener() {
+            @Override
+            public void process(DynamicConfigEvent event) {
+                System.out.printf(Locale.ENGLISH, "key notify %s key %s, content: %s%n"
+                , event.getEventType(), event.getKey(), event.getContent());
+            }
+        });
+        service.addGroupListener("service=flowControlDemo", new DynamicConfigListener() {
+            @Override
+            public void process(DynamicConfigEvent event) {
+                System.out.printf(Locale.ENGLISH, "group notify %s key %s, content: %s%n"
+                        , event.getEventType(), event.getKey(), event.getContent());
+            }
+        });
+    }
+
+    @Test
+    public void testRemoveConfig() {
+        final DynamicConfigService service = ServiceManager.getService(DynamicConfigService.class);
+        service.removeConfig("rule3", "e=f&a=b&c=d");
     }
 }

--- a/sermant-agentcore/sermant-agentcore-core/src/test/java/com/huawei/sermant/core/service/dynamicconfig/kie/PublishTest.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/test/java/com/huawei/sermant/core/service/dynamicconfig/kie/PublishTest.java
@@ -6,6 +6,9 @@ package com.huawei.sermant.core.service.dynamicconfig.kie;
 
 import com.huawei.sermant.core.common.CommonConstant;
 import com.huawei.sermant.core.common.LoggerFactory;
+import com.huawei.sermant.core.service.ServiceManager;
+import com.huawei.sermant.core.service.dynamicconfig.BaseTest;
+import com.huawei.sermant.core.service.dynamicconfig.DynamicConfigService;
 import com.huawei.sermant.core.service.dynamicconfig.kie.client.http.DefaultHttpClient;
 import com.huawei.sermant.core.service.dynamicconfig.kie.client.http.HttpResult;
 import com.huawei.sermant.core.service.dynamicconfig.kie.listener.SubscriberManager;
@@ -25,12 +28,7 @@ import java.util.UUID;
  * @author zhouss
  * @since 2021-12-02
  */
-public class PublishTest {
-
-    @Before
-    public void initLog() {
-        LoggerFactory.init(Collections.singletonMap(CommonConstant.LOG_SETTING_FILE_KEY, "log"));
-    }
+public class PublishTest extends BaseTest {
 
     @Test
     public void testPost() {
@@ -55,4 +53,14 @@ public class PublishTest {
         Assert.assertTrue(result);
     }
 
+    @Test
+    public void testPublishSameKey() {
+        String key = "rule3";
+        String group = "a=b&c=d&e=f";
+        final DynamicConfigService service = ServiceManager.getService(DynamicConfigService.class);
+        service.publishConfig(key, group, "1");
+        service.publishConfig(key, group, "3");
+        final String config = service.getConfig(key, group);
+        Assert.assertEquals("3", config);
+    }
 }


### PR DESCRIPTION
【issue号/问题单号/需求单号】#311

【修改内容】
1、修复KIE发布配置存在相同key报错问题，存在相同的key转为更新值
2、重构KIE对单个key监听机制，增加group的单个key进行监听能力
3、修复在增加单个key时，group不规范时的处理
4、新增移除单个配置的方法实现

【用例描述】暂无用例

【自测情况】本地自测通过

【影响范围】使用配置中心的模块：灰度发布、注册中心迁移@provenceee； 流控模块
