### PR TITLE
【BUG】修复zk动态配置实现中遍历子节点时带有'/'的问题

### DIFF
--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/service/dynamicconfig/zookeeper/ZooKeeperDynamicConfigService.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/service/dynamicconfig/zookeeper/ZooKeeperDynamicConfigService.java
@@ -157,7 +157,7 @@ public class ZooKeeperDynamicConfigService extends DynamicConfigService {
         final List<String> keys = new ArrayList<>();
         for (String keyPath : zkClient.listAllNodes(groupPath)) {
             if (keyPath.startsWith(groupPath)) {
-                keys.add(keyPath.substring(groupPath.length()));
+                keys.add(keyPath.substring(groupPath.length() + 1));
             }
         }
         return keys;


### PR DESCRIPTION
【问题单号】#312

【修改内容】修复zk动态配置实现中遍历子节点时带有'/'的问题

【用例描述】暂无用例

【自测情况】本地测试通过

【影响范围】动态配置系统zk实现