### PR TITLE
【Fix】修复流控与注册中心插件bug

### DIFF
--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-service/pom.xml
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-service/pom.xml
@@ -175,7 +175,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>1.30</version>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/sermant-plugins/sermant-register-center/spring-cloud-register-plugin/src/main/java/com/huawei/register/context/RegisterContext.java
+++ b/sermant-plugins/sermant-register-center/spring-cloud-register-plugin/src/main/java/com/huawei/register/context/RegisterContext.java
@@ -17,6 +17,7 @@
 package com.huawei.register.context;
 
 import com.huawei.register.handler.SingleStateCloseHandler;
+import com.netflix.client.config.IClientConfig;
 import org.springframework.cloud.client.discovery.composite.CompositeDiscoveryClient;
 
 import java.util.ArrayList;
@@ -40,6 +41,11 @@ public enum RegisterContext {
      * 通常用于关闭定时服务
      */
     private Object registerWatch;
+
+    /**
+     * 当前实例注册基本信息
+     */
+    private IClientConfig iClientConfig;
 
     private final AtomicBoolean isAvailable = new AtomicBoolean(true);
 
@@ -84,5 +90,13 @@ public enum RegisterContext {
 
     public void setDiscoveryClient(CompositeDiscoveryClient discoveryClient) {
         this.discoveryClient = discoveryClient;
+    }
+
+    public IClientConfig getiClientConfig() {
+        return iClientConfig;
+    }
+
+    public void setiClientConfig(IClientConfig iClientConfig) {
+        this.iClientConfig = iClientConfig;
     }
 }

--- a/sermant-plugins/sermant-register-center/spring-cloud-register-plugin/src/main/java/com/huawei/register/enhancers/IClientConfigEnhancer.java
+++ b/sermant-plugins/sermant-register-center/spring-cloud-register-plugin/src/main/java/com/huawei/register/enhancers/IClientConfigEnhancer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.huawei.register.enhancers.health;
+package com.huawei.register.enhancers;
 
 import com.huawei.sermant.core.agent.definition.EnhanceDefinition;
 import com.huawei.sermant.core.agent.definition.MethodInterceptPoint;
@@ -24,26 +24,27 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.matcher.ElementMatchers;
 
 /**
- * consul健康检测增强
+ * 针对eureka，consul注册中心获取实例列表拦截
  *
  * @author zhouss
  * @since 2021-12-17
  */
-public class ConsulWatchConEnhancer implements EnhanceDefinition {
+public class IClientConfigEnhancer implements EnhanceDefinition {
 
     /**
-     * nacos心跳发送类
+     * 增强类的全限定名
+     * 该client注入优先级最高，因此只需拦截该client即可
      */
-    private static final String ENHANCE_CLASS = "org.springframework.cloud.consul.discovery.ConsulCatalogWatch";
+    private static final String ENHANCE_CLASS = "com.netflix.client.config.IClientConfig";
 
     /**
      * 拦截类的全限定名
      */
-    private static final String INTERCEPT_CLASS = "com.huawei.register.interceptors.health.ConsulWatchInterceptor";
+    private static final String INTERCEPT_CLASS = "com.huawei.register.interceptors.IClientConfigInterceptor";
 
     @Override
     public ClassMatcher enhanceClass() {
-        return ClassMatchers.named(ENHANCE_CLASS);
+        return ClassMatchers.hasSuperTypes(ENHANCE_CLASS);
     }
 
     @Override

--- a/sermant-plugins/sermant-register-center/spring-cloud-register-plugin/src/main/java/com/huawei/register/interceptors/IClientConfigInterceptor.java
+++ b/sermant-plugins/sermant-register-center/spring-cloud-register-plugin/src/main/java/com/huawei/register/interceptors/IClientConfigInterceptor.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2021-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.register.interceptors;
+
+import com.huawei.register.context.RegisterContext;
+import com.huawei.sermant.core.agent.interceptor.ConstructorInterceptor;
+import com.netflix.client.config.IClientConfig;
+
+/**
+ * 拦截ConsulCatalogWatch,用于后续关闭服务
+ *
+ * @author zhouss
+ * @since 2021-12-31
+ */
+public class IClientConfigInterceptor implements ConstructorInterceptor {
+    @Override
+    public void onConstruct(Object obj, Object[] allArguments) {
+        if (obj instanceof IClientConfig) {
+            RegisterContext.INSTANCE.setiClientConfig((IClientConfig) obj);
+        }
+    }
+}

--- a/sermant-plugins/sermant-register-center/spring-cloud-register-plugin/src/main/java/com/huawei/register/interceptors/health/EurekaHealthInterceptor.java
+++ b/sermant-plugins/sermant-register-center/spring-cloud-register-plugin/src/main/java/com/huawei/register/interceptors/health/EurekaHealthInterceptor.java
@@ -22,6 +22,7 @@ import com.huawei.sermant.core.agent.common.BeforeResult;
 import com.huawei.sermant.core.agent.interceptor.InstanceMethodInterceptor;
 import com.huawei.sermant.core.common.LoggerFactory;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Locale;
 import java.util.logging.Logger;
@@ -60,16 +61,16 @@ public class EurekaHealthInterceptor extends SingleStateCloseHandler implements 
     }
 
     @Override
-    protected void close() {
-        try {
-            // 关闭Eureka定时器
-            final Class<?> discoveryClientClass = Thread.currentThread().getContextClassLoader()
-                    .loadClass("com.netflix.discovery.DiscoveryClient");
-            discoveryClientClass.getDeclaredMethod("shutdown").invoke(target);
-            LOGGER.info("Eureka register center has been closed.");
-        } catch (Exception ex) {
-            LOGGER.warning(String.format(Locale.ENGLISH,
-                    "Closed eureka register center failed! %s", ex.getMessage()));
-        }
+    protected boolean needCloseRegisterCenter() {
+        return super.needCloseRegisterCenter() && super.target != null;
+    }
+
+    @Override
+    protected void close() throws Exception {
+        // 关闭Eureka定时器
+        final Class<?> discoveryClientClass = Thread.currentThread().getContextClassLoader()
+                .loadClass("com.netflix.discovery.DiscoveryClient");
+        discoveryClientClass.getDeclaredMethod("shutdown").invoke(target);
+        LOGGER.info("Eureka register center has been closed.");
     }
 }

--- a/sermant-plugins/sermant-register-center/spring-cloud-register-plugin/src/main/java/com/huawei/register/interceptors/health/NacosHealthInterceptor.java
+++ b/sermant-plugins/sermant-register-center/spring-cloud-register-plugin/src/main/java/com/huawei/register/interceptors/health/NacosHealthInterceptor.java
@@ -17,6 +17,7 @@
 package com.huawei.register.interceptors.health;
 
 import com.alibaba.nacos.client.naming.beat.BeatInfo;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.huawei.register.context.RegisterContext;
 import com.huawei.register.handler.SingleStateCloseHandler;
 import com.huawei.sermant.core.agent.common.BeforeResult;
@@ -44,12 +45,26 @@ public class NacosHealthInterceptor extends SingleStateCloseHandler implements I
 
     @Override
     public Object after(Object obj, Method method, Object[] arguments, Object result) {
-        if (result instanceof Long) {
-            long beat = (Long) result;
+        if (isValidResult(result)) {
+            if (result == null && RegisterContext.INSTANCE.compareAndSet(true, false)) {
+                doChange(obj, arguments, true, false);
+                return null;
+            }
+            long beat;
+            if (result instanceof ObjectNode) {
+                // 新版本
+                ObjectNode node = (ObjectNode) result;
+                beat = node.get("clientBeatInterval").asLong();
+            } else if (result instanceof Long) {
+                // 旧版本
+                beat = (Long) result;
+            } else {
+                return result;
+            }
             // 如果心跳为0L，则当前实例与nacos注册中心不通，针对该实例注册中心已失效
             if (beat == 0L && RegisterContext.INSTANCE.compareAndSet(true, false)) {
                 doChange(obj, arguments, true, false);
-            } else if (beat > 0L &&  RegisterContext.INSTANCE.compareAndSet(false, true)) {
+            } else if (beat > 0L && RegisterContext.INSTANCE.compareAndSet(false, true)) {
                 doChange(obj, arguments, false, true);
             } else {
                 return result;
@@ -58,20 +73,22 @@ public class NacosHealthInterceptor extends SingleStateCloseHandler implements I
         return result;
     }
 
+    private boolean isValidResult(Object result) {
+        // 低版本不可用则返回0L, 反之可用
+        // 高版本不可用返回空，可用返回ObjectNode, json格式({"clientBeatInterval":5000,"code":10200,"lightBeatEnabled":true}),
+        // 判断字段clientBeatInterval是否大于0L
+        return result == null || result instanceof Long || result instanceof ObjectNode;
+    }
+
     @Override
     public void onThrow(Object obj, Method method, Object[] arguments, Throwable t) {
     }
 
     @Override
     protected void close() {
-        try {
-            // 关闭nacos心跳发送
-            BeatInfo beatInfo = (BeatInfo) arguments[0];
-            beatInfo.setStopped(true);
-            LOGGER.info("Nacos heartbeat has been closed.");
-        } catch (Exception ex) {
-            LOGGER.warning(String.format(Locale.ENGLISH,
-                    "Closed nacos heartbeat failed! %s", ex.getMessage()));
-        }
+        // 关闭nacos心跳发送
+        BeatInfo beatInfo = (BeatInfo) arguments[0];
+        beatInfo.setStopped(true);
+        LOGGER.info("Nacos heartbeat has been closed.");
     }
 }

--- a/sermant-plugins/sermant-register-center/spring-cloud-register-plugin/src/main/java/com/huawei/register/interceptors/health/ZookeeperHealthInterceptor.java
+++ b/sermant-plugins/sermant-register-center/spring-cloud-register-plugin/src/main/java/com/huawei/register/interceptors/health/ZookeeperHealthInterceptor.java
@@ -73,25 +73,20 @@ public class ZookeeperHealthInterceptor extends SingleStateCloseHandler implemen
     }
 
     @Override
-    protected void close() {
-        try {
-            ZookeeperServiceWatch watch = (ZookeeperServiceWatch) target;
-            final Field curator = watch.getClass().getDeclaredField("curator");
-            curator.setAccessible(true);
-            Field modifiersField = Field.class.getDeclaredField("modifiers");
-            modifiersField.setAccessible(true);
-            final CuratorFramework client = (CuratorFramework) curator.get(target);
-            // 关闭客户端, 停止定时器
-            client.close();
-            final Field cache = watch.getClass().getDeclaredField("cache");
-            cache.setAccessible(true);
-            modifiersField.setInt(cache, cache.getModifiers() & ~Modifier.FINAL);
-            // 清空缓存
-            cache.set(target, null);
-            LOGGER.info("Zookeeper client has been closed.");
-        } catch (Exception ex) {
-            LOGGER.warning(String.format(Locale.ENGLISH,
-                    "Closed Zookeeper client failed! %s", ex.getMessage()));
-        }
+    protected void close() throws Exception {
+        ZookeeperServiceWatch watch = (ZookeeperServiceWatch) target;
+        final Field curator = watch.getClass().getDeclaredField("curator");
+        curator.setAccessible(true);
+        Field modifiersField = Field.class.getDeclaredField("modifiers");
+        modifiersField.setAccessible(true);
+        final CuratorFramework client = (CuratorFramework) curator.get(target);
+        // 关闭客户端, 停止定时器
+        client.close();
+        final Field cache = watch.getClass().getDeclaredField("cache");
+        cache.setAccessible(true);
+        modifiersField.setInt(cache, cache.getModifiers() & ~Modifier.FINAL);
+        // 清空缓存
+        cache.set(target, null);
+        LOGGER.info("Zookeeper client has been closed.");
     }
 }

--- a/sermant-plugins/sermant-register-center/spring-cloud-register-plugin/src/main/resources/META-INF/services/com.huawei.sermant.core.agent.definition.EnhanceDefinition
+++ b/sermant-plugins/sermant-register-center/spring-cloud-register-plugin/src/main/resources/META-INF/services/com.huawei.sermant.core.agent.definition.EnhanceDefinition
@@ -17,6 +17,7 @@
 com.huawei.register.enhancers.RegistrationEnhancer
 com.huawei.register.enhancers.ServerListEnhancer
 com.huawei.register.enhancers.DiscoveryClientEnhancer
+com.huawei.register.enhancers.IClientConfigEnhancer
 com.huawei.register.enhancers.DiscoveryClientConfigurationEnhancer
 com.huawei.register.enhancers.health.EurekaHealthEnhancer
 com.huawei.register.enhancers.health.NacosHealthEnhancer

--- a/sermant-plugins/sermant-register-center/spring-cloud-register-service/pom.xml
+++ b/sermant-plugins/sermant-register-center/spring-cloud-register-service/pom.xml
@@ -44,7 +44,6 @@
             <version>${spring-cloud-version}</version>
             <scope>provided</scope>
         </dependency>
-
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
@@ -64,6 +63,13 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>1.7.33</version>
+        </dependency>
+
+        <!--test 依赖-->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/sermant-plugins/sermant-register-center/spring-cloud-register-service/src/main/java/com/huawei/register/service/client/ScClient.java
+++ b/sermant-plugins/sermant-register-center/spring-cloud-register-service/src/main/java/com/huawei/register/service/client/ScClient.java
@@ -131,7 +131,7 @@ public class ScClient {
         microserviceInstance.setVersion(registerConfig.getVersion());
         microserviceInstance.setHostName(registration.getHost());
         microserviceInstance.setEndpoints(buildEndpoints(registration));
-        Map<String, String> meta = registration.getMetadata();
+        Map<String, String> meta = new HashMap<String, String>(registration.getMetadata());
         meta.put(REG_VERSION_KEY, registerConfig.getVersion());
         microserviceInstance.setProperties(meta);
         return microserviceInstance;

--- a/sermant-plugins/sermant-register-center/spring-cloud-register-service/src/main/java/com/huawei/register/service/impl/RegisterCenterServiceImpl.java
+++ b/sermant-plugins/sermant-register-center/spring-cloud-register-service/src/main/java/com/huawei/register/service/impl/RegisterCenterServiceImpl.java
@@ -66,7 +66,16 @@ public class RegisterCenterServiceImpl implements RegisterCenterService {
 
     @Override
     public void replaceServerList(Object target, BeforeResult beforeResult) {
-        final String serviceId = (String) CommonUtils.getFieldValue(target, "serviceId");
+        String serviceId = (String) CommonUtils.getFieldValue(target, "serviceId");
+        if (serviceId == null && RegisterContext.INSTANCE.getiClientConfig() != null) {
+            // 若未获取到服务名，则从注册基本信息获取
+            serviceId = RegisterContext.INSTANCE.getiClientConfig().getClientName();
+        }
+        if (serviceId == null) {
+            // 无法执行替换
+            LOGGER.warning("Can not acquire the name of service, the process to replace instance won't be finished!");
+            return;
+        }
         if (useOriginRegisterCenter()) {
             final List<ServiceInstance> serviceInstances = queryServiceInstances(serviceId);
             if (!serviceInstances.isEmpty()) {


### PR DESCRIPTION
【issue号/问题单号/需求单号】#315

【修改内容】
1、兼容nacos高版本健康检查
2、兼容consul高版本健康检查
3、修复低版本注册中心日志桥接问题，避免使用宿主日志，导致应用无法启动
4、修复流控在低版本yaml获取不到的问题
5、修复Eureka健康检查可能出现的空指针问题
6、针对关闭注册中心，进行统一异常处理，针对关闭失败的场景进行关闭状态重置
7、增加拦截获取服务基本信息的增强点，以便于在注册发现时无法获取服务名的问题

【用例描述】暂无用例

【自测情况】本地测试通过

【影响范围】流控与注册中心-spring插件
