### PR TITLE
【BUG】修复拦截带有子类的方法时，匹配会将反省加加入superclass

### DIFF
--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/plugin/agent/matcher/ClassMatcher.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/plugin/agent/matcher/ClassMatcher.java
@@ -242,7 +242,7 @@ public abstract class ClassMatcher implements ElementMatcher<TypeDescription> {
      */
     private static boolean superTypeCheck(TypeDescription typeDescription, Collection<String> superTypeNames) {
         final Set<String> superTypeNameSet = new HashSet<String>(superTypeNames);
-        if (superTypeNameSet.contains(typeDescription.getActualName())) {
+        if (superTypeNameSet.contains(typeDescription.asErasure().getActualName())) {
             return false;
         }
         final Queue<TypeDefinition> queue = new LinkedList<TypeDefinition>();
@@ -253,11 +253,11 @@ public abstract class ClassMatcher implements ElementMatcher<TypeDescription> {
             superTypeNameSet.remove(current.getActualName());
             final TypeList.Generic interfaces = current.getInterfaces();
             if (!interfaces.isEmpty()) {
-                queue.addAll(interfaces);
+                queue.addAll(interfaces.asErasures());
             }
             final TypeDefinition superClass = current.getSuperClass();
             if (superClass != null) {
-                queue.add(superClass);
+                queue.add(superClass.asErasure());
             }
         }
         return superTypeNameSet.isEmpty();


### PR DESCRIPTION
【issue号/问题单号/需求单号】#337

【修改内容】修复拦截带有子类的方法时，匹配会将反省加加入superclass

【用例描述】暂不需测试用例

【自测情况】1、本地静态检查通过

【影响范围】1、对用户的使用没有影响）