### PR TITLE
【BUG】录制插件回访模块依赖报错问题修复

### DIFF
--- a/sermant-plugins/sermant-flowrecord/flowrecord-replay/flowrecord-console/pom.xml
+++ b/sermant-plugins/sermant-flowrecord/flowrecord-replay/flowrecord-console/pom.xml
@@ -115,6 +115,11 @@
             <groupId>io.grpc</groupId>
             <artifactId>grpc-stub</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>${spring.bean.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <extensions>

--- a/sermant-plugins/sermant-flowrecord/flowrecord-replay/pom.xml
+++ b/sermant-plugins/sermant-flowrecord/flowrecord-replay/pom.xml
@@ -35,10 +35,10 @@
         <elasticsearch.client.version>7.5.0</elasticsearch.client.version>
         <redis.clients.version>3.2.0</redis.clients.version>
         <junit.version>4.12</junit.version>
-        <spring.test.version>5.0.9.RELEASE</spring.test.version>
+        <spring.test.version>5.3.14</spring.test.version>
         <lombok.version>1.18.10</lombok.version>
         <fastjson.version>1.2.72</fastjson.version>
-        <spring.bean.version>5.2.9.RELEASE</spring.bean.version>
+        <spring.bean.version>5.3.9</spring.bean.version>
         <kafka.clients.version>2.3.0</kafka.clients.version>
         <springframework.kafka.test.version>2.5.6.RELEASE</springframework.kafka.test.version>
         <kafka.unit.test>1.0</kafka.unit.test>


### PR DESCRIPTION
【issue号/问题单号/需求单号】#347

【修改内容】

1.录制插件回放模块spring依赖版本修改
2.flowrecord-console模块添加spring-context依赖

【用例描述】暂不需用例
【自测情况】1、本地静态检查通过，可编译，可运行

【影响范围】1、使用录制插件的用户可以正常编译运行flowreplay模块