### PR TITLE
backend添加心跳数据缓存，不强依赖kafka

### DIFF
--- a/sermant-backend/src/main/java/com/huawei/sermant/backend/cache/HeartbeatCache.java
+++ b/sermant-backend/src/main/java/com/huawei/sermant/backend/cache/HeartbeatCache.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.sermant.backend.cache;
+
+import com.huawei.sermant.backend.entity.HeartbeatEntity;
+
+import java.util.HashMap;
+
+/**
+ * 心跳数据缓存
+ *
+ * @author xuezechao
+ * @since 2022-02-15
+ */
+public class HeartbeatCache {
+
+    private static HashMap<String, HeartbeatEntity> heartbeatMessages = new HashMap<>();
+
+    private HeartbeatCache() {
+    }
+
+    public static HashMap<String, HeartbeatEntity> getHeartbeatMessages() {
+        return heartbeatMessages;
+    }
+}

--- a/sermant-backend/src/main/java/com/huawei/sermant/backend/common/conf/KafkaConf.java
+++ b/sermant-backend/src/main/java/com/huawei/sermant/backend/common/conf/KafkaConf.java
@@ -96,4 +96,7 @@ public class KafkaConf {
 
     @Value("${kafka.max.block.ms}")
     private String kafkaMaxBlockMs;
+
+    @Value("${heartbeat.cache}")
+    private String isHeartbeatCache;
 }

--- a/sermant-backend/src/main/resources/application.properties
+++ b/sermant-backend/src/main/resources/application.properties
@@ -29,6 +29,8 @@ kafka.heartbeat.topic=topic-heartbeat
 netty.port=6888
 netty.wait.time=60
 
+heartbeat.cache=true
+
 datatype.topic.mapping.0=topic-heartbeat
 datatype.topic.mapping.1=topic-log
 datatype.topic.mapping.2=topic-flowcontrol


### PR DESCRIPTION
【issue号/问题单号/需求单号】#349

【修改内容】backend增加心跳数据缓存

【用例描述】暂不需用例

【自测情况】1、本地静态检查通过

【影响范围】1、入门用户不需部署kafka即可在前端界面看到框架和插件运行状态