### PR TITLE
【fix】修复dubbo注册插件加载配置类与找不到guava类的bug

### DIFF
--- a/sermant-plugins/sermant-register-center/dubbo-register-plugin/pom.xml
+++ b/sermant-plugins/sermant-register-center/dubbo-register-plugin/pom.xml
@@ -40,6 +40,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>com.huawei.sermant</groupId>
+            <artifactId>register-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/sermant-plugins/sermant-register-center/dubbo-register-service/pom.xml
+++ b/sermant-plugins/sermant-register-center/dubbo-register-service/pom.xml
@@ -18,6 +18,7 @@
         <servicecomb.version>2.5.3</servicecomb.version>
         <dubbo.version>2.7.15</dubbo.version>
         <alibaba.dubbo.version>2.6.12</alibaba.dubbo.version>
+        <guava.version>31.0.1-jre</guava.version>
         <package.plugin.type>service</package.plugin.type>
         <config.skip.flag>false</config.skip.flag>
     </properties>
@@ -54,10 +55,9 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.huawei.sermant</groupId>
-            <artifactId>register-common</artifactId>
-            <version>${project.version}</version>
-            <scope>compile</scope>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.dubbo</groupId>


### PR DESCRIPTION
【issue号/问题单号/需求单号】 #373 

【修改内容】修复dubbo注册插件加载配置类与找不到guava类的bug

【检查者】@fuziye01 @HapThorin @beetle-man @xuezechao1 @justforstudy-A

【用例描述】单元测试通过

【自测情况】本地测试通过

【影响范围】注册插件