### PR TITLE
【fix】修复若干流控bug

### DIFF
--- a/sermant-plugins/sermant-flowcontrol/config/config.yaml
+++ b/sermant-plugins/sermant-flowcontrol/config/config.yaml
@@ -2,7 +2,7 @@
 flow.control.plugin:
   openMetricCollector: ${plugin.flowcontrol.collect.metric:false}   # 是否开启指标数据采集
   useCseRule: ${plugin.flowcontrol.adapte.cse:true} # 是否使用cse规则配置
+  useAgentConfigCenter: ${plugin.flowcontrol.use.agent.config_center:false} # 是否使用agent配置中心, 该配置仅当useCseRule=true时生效
   customLabel: ${plugin.flowcontrol.custom.label:public} # 默认标签 useCseRule=true生效
   customLabelValue: ${plugin.flowcontrol.custom.label_value:default} # 默认标签值
   configKieAddress: ${plugin.flowcontrol.kie.address:localhost:30110} # 当流控不使用agent配置中心时生效
-  useAgentConfigCenter: ${plugin.flowcontrol.use.agent.config_center:false} # 是否使用agent配置中心

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/adapte/cse/match/MatchManager.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/adapte/cse/match/MatchManager.java
@@ -18,9 +18,9 @@
 package com.huawei.flowcontrol.common.adapte.cse.match;
 
 import com.huawei.flowcontrol.common.adapte.cse.ResolverManager;
-import com.huawei.flowcontrol.common.adapte.cse.entity.CseMatchRequest;
 import com.huawei.flowcontrol.common.entity.RequestEntity;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -37,34 +37,31 @@ public enum MatchManager {
      */
     INSTANCE;
 
-    /**
-     * 从dubbo attachment获取version版本
-     */
-    public static final String DUBBO_ATTACHMENT_VERSION = "version";
+    private static final int DEFAULT_BUSINESS_SIZE = 4;
 
     /**
-     * 匹配所有的业务场景
+     * 匹配所有业务场景
      *
-     * @param request http请求
-     * @return 匹配的所有业务场景
+     * @param request 请求信息
+     * @return 匹配的业务场景
      */
     public Set<String> match(RequestEntity request) {
-        return match(buildRequest(request));
+        return match(request, null);
     }
 
     /**
-     * 匹配业务场景
+     * 匹配指定业务场景名
      *
-     * @param cseRequest 请求信息
+     * @param request      请求信息
+     * @param businessName 业务场景名
      * @return 匹配的业务场景
      */
-    public Set<String> match(CseMatchRequest cseRequest) {
+    public Set<String> match(RequestEntity request, String businessName) {
         // 匹配规则
-        final MatchGroupResolver resolver = ResolverManager.INSTANCE.getResolver(MatchGroupResolver.CONFIG_KEY);
-        final Map<String, BusinessMatcher> matchGroups = resolver.getRules();
-        final Set<String> result = new HashSet<String>();
+        final Map<String, BusinessMatcher> matchGroups = getMatchGroups(businessName);
+        final Set<String> result = new HashSet<>(DEFAULT_BUSINESS_SIZE);
         for (Map.Entry<String, BusinessMatcher> entry : matchGroups.entrySet()) {
-            if (entry.getValue().match(cseRequest.getApiPath(), cseRequest.getHeaders(), cseRequest.getHttpMethod())) {
+            if (entry.getValue().match(request.getApiPath(), request.getHeaders(), request.getMethod())) {
                 if (!ResolverManager.INSTANCE.hasMatchedRule(entry.getKey())) {
                     continue;
                 }
@@ -76,7 +73,16 @@ public enum MatchManager {
         return result;
     }
 
-    private CseMatchRequest buildRequest(RequestEntity entity) {
-        return new CseMatchRequest(entity.getApiPath(), entity.getHeaders(), entity.getMethod());
+    private Map<String, BusinessMatcher> getMatchGroups(String businessName) {
+        final MatchGroupResolver resolver = ResolverManager.INSTANCE.getResolver(MatchGroupResolver.CONFIG_KEY);
+        final Map<String, BusinessMatcher> matchGroups = resolver.getRules();
+        if (businessName == null) {
+            return matchGroups;
+        }
+        final BusinessMatcher businessMatcher = matchGroups.get(businessName);
+        if (businessMatcher == null) {
+            return Collections.emptyMap();
+        }
+        return Collections.singletonMap(businessName, businessMatcher);
     }
 }

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/adapte/cse/rule/syncer/CseRuleSyncer.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/adapte/cse/rule/syncer/CseRuleSyncer.java
@@ -52,8 +52,7 @@ public class CseRuleSyncer implements RuleSyncer {
      */
     private static final int MAX_WAIT_INTERVAL_MS = 60 * 5 * 1000;
 
-    private final Map<String, RuleDynamicConfigListener> listenerCache
-            = new LinkedHashMap<String, RuleDynamicConfigListener>();
+    private final Map<String, RuleDynamicConfigListener> listenerCache = new LinkedHashMap<>();
 
     private DynamicConfigService dynamicConfigurationFactoryService;
 
@@ -92,8 +91,8 @@ public class CseRuleSyncer implements RuleSyncer {
         } else {
             dynamicConfigurationFactoryService = new KieDynamicConfigService(pluginConfig.getConfigKieAddress(),
                     pluginConfig.getProject());
-            fillServiceMeta(pluginConfig);
         }
+        fillServiceMeta(pluginConfig);
     }
 
     private void fillServiceMeta(FlowControlConfig pluginConfig) {
@@ -126,7 +125,7 @@ public class CseRuleSyncer implements RuleSyncer {
     }
 
     private void buildServiceRequest() {
-        final HashMap<String, String> map = new HashMap<String, String>();
+        final HashMap<String, String> map = new HashMap<>();
         map.put("app", CseServiceMeta.getInstance().getApp());
         map.put("service", CseServiceMeta.getInstance().getServiceName());
         map.put("environment", CseServiceMeta.getInstance().getEnvironment());
@@ -134,14 +133,14 @@ public class CseRuleSyncer implements RuleSyncer {
     }
 
     private void buildAppRequest() {
-        final HashMap<String, String> map = new HashMap<String, String>();
+        final HashMap<String, String> map = new HashMap<>();
         map.put("app", CseServiceMeta.getInstance().getApp());
         map.put("environment", CseServiceMeta.getInstance().getEnvironment());
         listenerCache.put(LabelGroupUtils.createLabelGroup(map), new RuleDynamicConfigListener());
     }
 
     private void buildCustomRequest() {
-        final HashMap<String, String> map = new HashMap<String, String>();
+        final HashMap<String, String> map = new HashMap<>();
         map.put(CseServiceMeta.getInstance().getCustomLabel(), CseServiceMeta.getInstance().getCustomLabelValue());
         listenerCache.put(LabelGroupUtils.createLabelGroup(map), new RuleDynamicConfigListener());
     }

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/entity/AbstractRequestEntity.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/entity/AbstractRequestEntity.java
@@ -17,37 +17,30 @@
 
 package com.huawei.flowcontrol.common.entity;
 
+import java.util.Objects;
+
 /**
- * 修正结果, 该结果确定返回数据
+ * 用于统一重写equals与hashCode方法
  *
  * @author zhouss
- * @since 2022-02-09
+ * @since 2022-02-28
  */
-public class FixedResult {
-    /**
-     * 覆盖结果
-     */
-    private Object result;
-
-    /**
-     * 是否需要跳过调用
-     */
-    private boolean isSkip = false;
-
-    public Object getResult() {
-        return result;
+public abstract class AbstractRequestEntity implements RequestEntity {
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        AbstractRequestEntity that = (AbstractRequestEntity) obj;
+        return Objects.equals(getHeaders(), that.getHeaders()) && Objects.equals(getApiPath(), that.getApiPath())
+            && Objects.equals(getMethod(), that.getMethod());
     }
 
-    public void setResult(Object result) {
-        this.result = result;
-        this.isSkip = true;
-    }
-
-    public boolean isSkip() {
-        return isSkip;
-    }
-
-    public void setSkip(boolean isNeedSkip) {
-        this.isSkip = isNeedSkip;
+    @Override
+    public int hashCode() {
+        return Objects.hash(getHeaders(), getApiPath(), getMethod());
     }
 }

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/entity/DubboRequestEntity.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/entity/DubboRequestEntity.java
@@ -25,7 +25,7 @@ import java.util.Map;
  * @author zhouss
  * @since 2022-01-22
  */
-public class DubboRequestEntity implements RequestEntity {
+public class DubboRequestEntity extends AbstractRequestEntity {
     /**
      * dubbo方法匹配类型
      */

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/entity/FlowControlResult.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/entity/FlowControlResult.java
@@ -15,37 +15,41 @@
  *
  */
 
-package com.huawei.flowcontrol.service;
+package com.huawei.flowcontrol.common.entity;
 
-import com.huawei.flowcontrol.common.entity.FlowControlResult;
-import com.huawei.flowcontrol.common.entity.RequestEntity;
+import com.huawei.flowcontrol.common.enums.FlowControlEnum;
 
 /**
- * http拦截
+ * 修正结果, 该结果确定返回数据
  *
  * @author zhouss
- * @since 2022-01-25
+ * @since 2022-02-09
  */
-public interface HttpService {
+public class FlowControlResult {
     /**
-     * 前置拦截
-     *
-     * @param requestEntity 请求信息
-     * @param fixedResult   修正结果
+     * 流控类型
      */
-    void onBefore(RequestEntity requestEntity, FlowControlResult fixedResult);
+    private FlowControlEnum flowControlEnum;
 
     /**
-     * 后置方法
-     *
-     * @param result 响应结果
+     * 是否需要跳过调用
      */
-    void onAfter(Object result);
+    private boolean isSkip = false;
 
-    /**
-     * 异常抛出方法
-     *
-     * @param throwable 异常信息
-     */
-    void onThrow(Throwable throwable);
+    public FlowControlEnum getResult() {
+        return flowControlEnum;
+    }
+
+    public void setResult(FlowControlEnum result) {
+        this.flowControlEnum = result;
+        this.isSkip = true;
+    }
+
+    public boolean isSkip() {
+        return isSkip;
+    }
+
+    public void setSkip(boolean isNeedSkip) {
+        this.isSkip = isNeedSkip;
+    }
 }

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/entity/HttpRequestEntity.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/entity/HttpRequestEntity.java
@@ -27,7 +27,7 @@ import java.util.Map;
  * @author zhouss
  * @since 2022-01-22
  */
-public class HttpRequestEntity implements RequestEntity {
+public class HttpRequestEntity extends AbstractRequestEntity {
     private String apiPath;
 
     private String pathInfo;

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/entity/RequestEntity.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/entity/RequestEntity.java
@@ -46,4 +46,21 @@ public interface RequestEntity {
      * @return 方法类型
      */
     String getMethod();
+
+    /**
+     * 必须实现equal方法
+     *
+     * @param obj 比较目标
+     * @return 是否相等
+     */
+    @Override
+    boolean equals(Object obj);
+
+    /**
+     * 必须实现hashCode编码
+     *
+     * @return 哈希码
+     */
+    @Override
+    int hashCode();
 }

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/handler/listener/HandlerRequestListener.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/handler/listener/HandlerRequestListener.java
@@ -15,37 +15,22 @@
  *
  */
 
-package com.huawei.flowcontrol.service;
+package com.huawei.flowcontrol.common.handler.listener;
 
-import com.huawei.flowcontrol.common.entity.FlowControlResult;
 import com.huawei.flowcontrol.common.entity.RequestEntity;
 
 /**
- * http拦截
+ * 处理器配置关联请求更新监听器
  *
  * @author zhouss
- * @since 2022-01-25
+ * @since 2022-02-28
  */
-public interface HttpService {
+public interface HandlerRequestListener {
     /**
-     * 前置拦截
+     * 通知配置变更
      *
-     * @param requestEntity 请求信息
-     * @param fixedResult   修正结果
+     * @param entity    关联请求
+     * @param updateKey 更新的业务场景
      */
-    void onBefore(RequestEntity requestEntity, FlowControlResult fixedResult);
-
-    /**
-     * 后置方法
-     *
-     * @param result 响应结果
-     */
-    void onAfter(Object result);
-
-    /**
-     * 异常抛出方法
-     *
-     * @param throwable 异常信息
-     */
-    void onThrow(Throwable throwable);
+    void notify(RequestEntity entity, String updateKey);
 }

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/handler/retry/RetryContext.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/handler/retry/RetryContext.java
@@ -18,8 +18,7 @@
 package com.huawei.flowcontrol.common.handler.retry;
 
 /**
- * 重试上下文，用于管理重试策略
- * 基于不同的宿主框架类型
+ * 重试上下文，用于管理重试策略 基于不同的宿主框架类型
  *
  * @author zhouss
  * @since 2022-01-26
@@ -36,7 +35,7 @@ public enum RetryContext {
         return retryThreadLocal.get();
     }
 
-    public void setRetry(Retry retry) {
+    public void markRetry(Retry retry) {
         retryThreadLocal.set(retry);
     }
 
@@ -44,7 +43,7 @@ public enum RetryContext {
         retryThreadLocal.remove();
     }
 
-    public boolean isReady() {
+    public boolean isMarkedRetry() {
         return retryThreadLocal.get() != null;
     }
 }

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/support/ReflectMethodCacheSupport.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/support/ReflectMethodCacheSupport.java
@@ -36,8 +36,11 @@ public class ReflectMethodCacheSupport {
 
     protected final Method getInvokerMethod(String methodName,
             Function<? super String, ? extends Method> mappingFunction) {
-        if (methodName == null || mappingFunction == null) {
+        if (methodName == null) {
             return null;
+        }
+        if (mappingFunction == null) {
+            return cacheMethods.get(methodName);
         }
         return cacheMethods.computeIfAbsent(methodName, mappingFunction);
     }

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/retry/FeignRequestDeclarer.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/retry/FeignRequestDeclarer.java
@@ -32,7 +32,7 @@ public class FeignRequestDeclarer extends AbstractPluginDeclarer {
     /**
      * 增强类的全限定名
      */
-    private static final String ENHANCE_CLASS = "feign.Client";
+    private static final String ENHANCE_CLASS = "org.springframework.cloud.openfeign.ribbon.LoadBalancerFeignClient";
 
     /**
      * 拦截类的全限定名
@@ -41,7 +41,7 @@ public class FeignRequestDeclarer extends AbstractPluginDeclarer {
 
     @Override
     public ClassMatcher getClassMatcher() {
-        return ClassMatcher.isExtendedFrom(ENHANCE_CLASS);
+        return ClassMatcher.nameEquals(ENHANCE_CLASS);
     }
 
     @Override

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/service/DubboService.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/service/DubboService.java
@@ -17,7 +17,7 @@
 
 package com.huawei.flowcontrol.service;
 
-import com.huawei.flowcontrol.common.entity.FixedResult;
+import com.huawei.flowcontrol.common.entity.FlowControlResult;
 import com.huawei.flowcontrol.common.entity.RequestEntity;
 
 /**
@@ -31,16 +31,16 @@ public interface DubboService {
      * 前置拦截
      *
      * @param requestEntity 请求信息
-     * @param fixedResult 修正结果
-     * @param isProvider 是否为生产者
+     * @param fixedResult   修正结果
+     * @param isProvider    是否为生产者
      */
-    void onBefore(RequestEntity requestEntity, FixedResult fixedResult, boolean isProvider);
+    void onBefore(RequestEntity requestEntity, FlowControlResult fixedResult, boolean isProvider);
 
     /**
      * 后置方法
      *
-     * @param result 响应结果
-     * @param isProvider 是否为生产者
+     * @param result       响应结果
+     * @param isProvider   是否为生产者
      * @param hasException 是否发生调用异常， dubbo场景发生异常会调用after方法
      */
     @SuppressWarnings("checkstyle:RegexpSingleline")
@@ -49,7 +49,7 @@ public interface DubboService {
     /**
      * 异常抛出方法
      *
-     * @param throwable 异常信息
+     * @param throwable  异常信息
      * @param isProvider 是否为生产者
      * @return 是否需要重试
      */

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-resilience4j-service/src/main/java/com/huawei/fowcontrol/res4j/service/DubboRest4jServiceImpl.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-resilience4j-service/src/main/java/com/huawei/fowcontrol/res4j/service/DubboRest4jServiceImpl.java
@@ -17,7 +17,7 @@
 
 package com.huawei.fowcontrol.res4j.service;
 
-import com.huawei.flowcontrol.common.entity.FixedResult;
+import com.huawei.flowcontrol.common.entity.FlowControlResult;
 import com.huawei.flowcontrol.common.entity.RequestEntity;
 import com.huawei.flowcontrol.service.rest4j.DubboRest4jService;
 import com.huawei.fowcontrol.res4j.handler.HandlerFacade;
@@ -34,11 +34,15 @@ public class DubboRest4jServiceImpl extends DubboRest4jService {
 
     @Override
     @SuppressWarnings("checkstyle:IllegalCatch")
-    public void onBefore(RequestEntity requestEntity, FixedResult fixedResult, boolean isProvider) {
+    public void onBefore(RequestEntity requestEntity, FlowControlResult fixedResult, boolean isProvider) {
         try {
             HandlerFacade.INSTANCE.injectHandlers(requestEntity, isProvider);
         } catch (Exception ex) {
             Rest4jExceptionUtils.handleException(ex, fixedResult);
+            if (Rest4jExceptionUtils.isNeedReleasePermit(ex)) {
+                // 流控异常及时释放资源
+                HandlerFacade.INSTANCE.releaseDubboPermit();
+            }
             HandlerFacade.INSTANCE.removeHandlers(isProvider);
         }
     }

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-resilience4j-service/src/main/java/com/huawei/fowcontrol/res4j/service/HttpRest4jServiceImpl.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-resilience4j-service/src/main/java/com/huawei/fowcontrol/res4j/service/HttpRest4jServiceImpl.java
@@ -17,7 +17,7 @@
 
 package com.huawei.fowcontrol.res4j.service;
 
-import com.huawei.flowcontrol.common.entity.FixedResult;
+import com.huawei.flowcontrol.common.entity.FlowControlResult;
 import com.huawei.flowcontrol.common.entity.RequestEntity;
 import com.huawei.flowcontrol.service.rest4j.HttpRest4jService;
 import com.huawei.fowcontrol.res4j.handler.HandlerFacade;
@@ -32,11 +32,15 @@ import com.huawei.fowcontrol.res4j.util.Rest4jExceptionUtils;
 public class HttpRest4jServiceImpl extends HttpRest4jService {
     @Override
     @SuppressWarnings("checkstyle:IllegalCatch")
-    public void onBefore(RequestEntity requestEntity, FixedResult fixedResult) {
+    public void onBefore(RequestEntity requestEntity, FlowControlResult fixedResult) {
         try {
             HandlerFacade.INSTANCE.injectHandlers(requestEntity);
         } catch (Exception ex) {
             Rest4jExceptionUtils.handleException(ex, fixedResult);
+            if (Rest4jExceptionUtils.isNeedReleasePermit(ex)) {
+                // 流控异常及时释放资源
+                HandlerFacade.INSTANCE.releasePermit();
+            }
             HandlerFacade.INSTANCE.removeHandlers();
         }
     }

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/main/java/com/huawei/flowcontrol/adapte/cse/rule/converter/RateLimitingRuleConverter.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/main/java/com/huawei/flowcontrol/adapte/cse/rule/converter/RateLimitingRuleConverter.java
@@ -23,6 +23,8 @@ import com.huawei.flowcontrol.common.config.CommonConst;
 import com.alibaba.csp.sentinel.slots.block.RuleConstant;
 import com.alibaba.csp.sentinel.slots.block.flow.FlowRule;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.Collections;
 import java.util.List;
 
@@ -38,8 +40,9 @@ public class RateLimitingRuleConverter implements RuleConverter<RateLimitingRule
         final FlowRule flowRule = new FlowRule();
 
         // 转换为rate/s, sentinel当前只能以1S为单位进行统计, 因此此处做一定请求比例转换
-        flowRule.setCount(resilienceRule.getRate() * CommonConst.RATE_DIV_POINT
-            / resilienceRule.getParsedLimitRefreshPeriod());
+        final BigDecimal divide = BigDecimal.valueOf(resilienceRule.getRate() * CommonConst.RATE_DIV_POINT)
+            .divide(BigDecimal.valueOf(resilienceRule.getParsedLimitRefreshPeriod()), RoundingMode.CEILING);
+        flowRule.setCount(divide.doubleValue());
         flowRule.setGrade(RuleConstant.FLOW_GRADE_QPS);
         flowRule.setResource(resilienceRule.getName());
         return Collections.singletonList(flowRule);

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/main/java/com/huawei/flowcontrol/service/DubboServiceImpl.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/main/java/com/huawei/flowcontrol/service/DubboServiceImpl.java
@@ -17,7 +17,7 @@
 
 package com.huawei.flowcontrol.service;
 
-import com.huawei.flowcontrol.common.entity.FixedResult;
+import com.huawei.flowcontrol.common.entity.FlowControlResult;
 import com.huawei.flowcontrol.common.entity.RequestEntity;
 import com.huawei.flowcontrol.entry.EntryFacade;
 import com.huawei.flowcontrol.service.sen.DubboSenService;
@@ -35,7 +35,7 @@ public class DubboServiceImpl extends DubboSenService {
     private final Exception dubboException = new Exception("dubbo exception");
 
     @Override
-    public void onBefore(RequestEntity requestEntity, FixedResult fixedResult, boolean isProvider) {
+    public void onBefore(RequestEntity requestEntity, FlowControlResult fixedResult, boolean isProvider) {
         try {
             EntryFacade.INSTANCE.tryEntry(requestEntity, isProvider);
         } catch (BlockException blockException) {

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/main/java/com/huawei/flowcontrol/service/HttpServiceImpl.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/main/java/com/huawei/flowcontrol/service/HttpServiceImpl.java
@@ -17,7 +17,7 @@
 
 package com.huawei.flowcontrol.service;
 
-import com.huawei.flowcontrol.common.entity.FixedResult;
+import com.huawei.flowcontrol.common.entity.FlowControlResult;
 import com.huawei.flowcontrol.common.entity.RequestEntity;
 import com.huawei.flowcontrol.entry.EntryFacade;
 import com.huawei.flowcontrol.service.sen.HttpSenService;
@@ -34,7 +34,7 @@ import com.alibaba.csp.sentinel.slots.block.BlockException;
  */
 public class HttpServiceImpl extends HttpSenService {
     @Override
-    public void onBefore(RequestEntity requestEntity, FixedResult fixedResult) {
+    public void onBefore(RequestEntity requestEntity, FlowControlResult fixedResult) {
         try {
             EntryFacade.INSTANCE.tryEntry(requestEntity);
         } catch (BlockException ex) {

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/main/java/com/huawei/flowcontrol/util/SentinelRuleUtil.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/main/java/com/huawei/flowcontrol/util/SentinelRuleUtil.java
@@ -18,7 +18,7 @@ package com.huawei.flowcontrol.util;
 
 import com.huawei.flowcontrol.adapte.cse.rule.isolate.IsolateThreadException;
 import com.huawei.flowcontrol.adapte.cse.rule.isolate.IsolateThreadRule;
-import com.huawei.flowcontrol.common.entity.FixedResult;
+import com.huawei.flowcontrol.common.entity.FlowControlResult;
 import com.huawei.flowcontrol.common.enums.FlowControlEnum;
 
 import com.alibaba.csp.sentinel.slots.block.AbstractRule;
@@ -76,7 +76,7 @@ public class SentinelRuleUtil {
         }
     }
 
-    public static void handleBlockException(BlockException blockException, FixedResult fixedResult) {
+    public static void handleBlockException(BlockException blockException, FlowControlResult fixedResult) {
         if (blockException instanceof FlowException) {
             fixedResult.setResult(FlowControlEnum.RATE_LIMITED);
         } else if (blockException instanceof DegradeException) {


### PR DESCRIPTION
【issue号/问题单号/需求单号】#378

【修改内容】
- 修复流控切换为非适配模式规则不生效的问题
- 修复流控规则转换时存在的精度丢失问题

- 针对策略匹配增加缓存，防止每次请求都需匹配策略
- 优化重试逻辑
- 修复alibaba dubbo类使用错误问题
- 修复feign拦截header移除报错问题
- 修复隔离仓与熔断结合使用导致一直报隔离异常问题

【用例描述】暂无用例

【自测情况】本地测试通过

【影响范围】仅对当前模块产生影响
