### PR TITLE
actions 添加 release版本发布

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,0 +1,48 @@
+on:
+  push:
+    tags:
+      - 'v*'
+
+name: Create Release
+
+jobs:
+  auto-create-release:
+    name: Auto Create Release
+    runs-on: windows-latest
+    steps:
+      - name: Checkout Source # 检出代码
+        uses: actions/checkout@v2
+      - name: Set up JDK 8 # 构建jdk运行环境
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+          cache: maven
+      - name: Create License Binary Suffix
+        run: |
+          mvn license:aggregate-add-third-party
+      - name: Build with Maven
+        run: |
+          mvn -B package -DskipTests --file pom.xml
+          mkdir ${{ github.workspace }}/package
+          cp ${{ github.workspace }}/sermant-agent-*.tar ${{ github.workspace }}/package/sermant-agent.tar
+      - name: Create Release # 自动发布release版本
+        id: create_release
+        uses: actions/create-release@v1.1.4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+      - name: Upload Release # 上传release包
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ github.workspace }}/package/sermant-agent.tar
+          asset_name: sermant-agent.tar
+          asset_content_type: application/tar


### PR DESCRIPTION
【issue号/问题单号/需求单号】#389

【修改内容】增加了release发布actions

【用例描述】不需测试用例

【自测情况】1、本地静态检查通过

【影响范围】1、需要发布release时通过执行 `git tag -a "${tag-name}" -m "${release-message}"` 创建tag，执行 `git push --tags` 即可出发release发布