### PR TITLE
【feature】agent-core新增链路追踪服务

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
         <junit.version>4.12</junit.version>
         <junit.jupiter.version>5.8.1</junit.jupiter.version>
         <mockito-core.version>3.9.0</mockito-core.version>
+        <mockito-inline.version>3.9.0</mockito-inline.version>
 
         <clean.plugin.version>2.5</clean.plugin.version>
         <compiler.plugin.version>3.8.1</compiler.plugin.version>
@@ -241,6 +242,12 @@
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
                 <version>${mockito-core.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-inline</artifactId>
+                <version>${mockito-inline.version}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>

--- a/sermant-agentcore/sermant-agentcore-core/pom.xml
+++ b/sermant-agentcore/sermant-agentcore-core/pom.xml
@@ -93,7 +93,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <artifactId>mockito-inline</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -170,6 +170,10 @@
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm-commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/service/tracing/ExtractService.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/service/tracing/ExtractService.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.huawei.sermant.core.service.tracing;
+
+import com.huawei.sermant.core.service.tracing.common.TracingRequest;
+
+/**
+ * 将Span上下文提取出载体的函数式接口
+ *
+ * @param <T>
+ * @author luanwenfei
+ * @since 2022-02-28
+ */
+@FunctionalInterface
+public interface ExtractService<T> {
+    /**
+     * 跨进程链路追踪，需要将SpanContext从协议载体中取出，
+     * TRACE_ID->TraceId、PARENT_SPAN_ID->ParentSpanId、SPAN_ID_PREFIX->SpanIdPrefix为必选项
+     *
+     * @param tracingRequest SpanStart生命周期所需构建数据
+     * @param carrier 协议载体
+     */
+    void getFromCarrier(TracingRequest tracingRequest, T carrier);
+}

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/service/tracing/InjectService.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/service/tracing/InjectService.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.huawei.sermant.core.service.tracing;
+
+import com.huawei.sermant.core.service.tracing.common.SpanEvent;
+
+/**
+ * 将Span上下文注入载体的函数式接口
+ *
+ * @param <T>
+ * @author luanwenfei
+ * @since 2022-02-28
+ */
+@FunctionalInterface
+public interface InjectService<T> {
+    /**
+     * 跨进程链路追踪，需要将SpanContext内容放入协议载体，
+     * TraceId->TRACE_ID、ParentSpanId->PARENT_SPAN_ID、NextSpanIdPrefix->SPAN_ID_PREFIX为必选项
+     *
+     * @param spanEvent span信息
+     * @param carrier SpanContext携带载体
+     */
+    void addToCarrier(SpanEvent spanEvent, T carrier);
+}

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/service/tracing/TracingService.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/service/tracing/TracingService.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.huawei.sermant.core.service.tracing;
+
+import com.huawei.sermant.core.service.BaseService;
+import com.huawei.sermant.core.service.tracing.common.SpanEvent;
+import com.huawei.sermant.core.service.tracing.common.TracingRequest;
+
+import java.util.Optional;
+
+/**
+ * 链路追踪服务接口
+ *
+ * @author luanwenfei
+ * @since 2022-02-28
+ */
+public interface TracingService extends BaseService {
+    /**
+     * 工作单元开始生命周期，用于非Provider和Consumer场景的工作单元
+     *
+     * @param tracingRequest 调用链路追踪生命周期时需要传入的参数
+     * @return 构建好的SpanEvent数据
+     */
+    Optional<SpanEvent> onNormalSpanStart(TracingRequest tracingRequest);
+
+    /**
+     * 工作单元开始生命周期，用于Provider场景的工作单元
+     *
+     * @param tracingRequest 调用链路追踪生命周期时需要传入的参数
+     * @param extractService 透传时，从载体提取数据的函数式接口
+     * @param carrier 协议载体
+     * @param <T> 泛型
+     * @return 构建好的SpanEvent数据
+     */
+    <T> Optional<SpanEvent> onProviderSpanStart(TracingRequest tracingRequest, ExtractService<T> extractService,
+        T carrier);
+
+    /**
+     * 工作单元开始生命周期，用于Consumer场景的工作单元
+     *
+     * @param tracingRequest 调用链路追踪生命周期时需要传入的参数
+     * @param injectService 透传时，注入载体的函数式接口
+     * @param carrier 协议载体
+     * @param <T> 泛型
+     * @return 构建好的SpanEvent数据
+     */
+    <T> Optional<SpanEvent> onConsumerSpanStart(TracingRequest tracingRequest, InjectService<T> injectService,
+        T carrier);
+
+    /**
+     * 工作单元结束生命周期
+     */
+    void onSpanFinally();
+
+    /**
+     * 工作单元异常生命周期
+     *
+     * @param throwable throwable
+     * @return 构建好的SpanEvent数据
+     */
+    Optional<SpanEvent> onSpanError(Throwable throwable);
+}

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/service/tracing/TracingServiceImpl.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/service/tracing/TracingServiceImpl.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.huawei.sermant.core.service.tracing;
+
+import com.huawei.sermant.core.common.LoggerFactory;
+import com.huawei.sermant.core.service.tracing.common.SpanEvent;
+import com.huawei.sermant.core.service.tracing.common.SpanEventContext;
+import com.huawei.sermant.core.service.tracing.common.TracingRequest;
+import com.huawei.sermant.core.service.tracing.sender.TracingSender;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.serializer.SerializerFeature;
+
+import java.util.Locale;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+/**
+ * 链路追踪接口的实现
+ *
+ * @author luanwenfei
+ * @since 2022-03-01
+ */
+public class TracingServiceImpl implements TracingService {
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
+    /**
+     * 每级最大span event个数
+     */
+    private static final int MAX_SPAN_EVENT_COUNT = 500;
+
+    /**
+     * 采样深度
+     */
+    private static final int MAX_SPAN_EVENT_DEPTH = 100;
+
+    private final TracingSender tracingSender = TracingSender.getInstance();
+
+    private final ThreadLocal<SpanEventContext> threadLocal = new ThreadLocal<>();
+
+    /**
+     * 链路采集开关标志位
+     */
+    private boolean isTracing;
+
+    @Override
+    public void start() {
+        this.isTracing = true;
+        tracingSender.start();
+        LOGGER.info("TracingService started.");
+    }
+
+    @Override
+    public void stop() {
+        this.isTracing = false;
+        tracingSender.stop();
+        LOGGER.info("TracingService stopped.");
+    }
+
+    @Override
+    public <T> Optional<SpanEvent> onProviderSpanStart(TracingRequest tracingRequest, ExtractService<T> extractService,
+        T carrier) {
+        if (!isTracing) {
+            return Optional.empty();
+        }
+
+        // 从协议载体中获取TraceId、SpanId等数据
+        extractService.getFromCarrier(tracingRequest, carrier);
+        if (!filterSpanDepth(tracingRequest)) {
+            return Optional.empty();
+        }
+        long startTime = System.currentTimeMillis();
+        SpanEventContext spanEventContext = new SpanEventContext(tracingRequest);
+        SpanEvent spanEvent = spanEventContext.getSpanEvent();
+        spanEvent.setStartTime(startTime);
+        threadLocal.set(spanEventContext);
+        return Optional.of(spanEvent);
+    }
+
+    @Override
+    public Optional<SpanEvent> onNormalSpanStart(TracingRequest tracingRequest) {
+        if (!isTracing) {
+            return Optional.empty();
+        }
+        Optional<SpanEvent> spanEventOptional = configureSpanEvent(tracingRequest);
+        if (!spanEventOptional.isPresent()) {
+            return spanEventOptional;
+        }
+        SpanEvent spanEvent = spanEventOptional.get();
+        return Optional.of(spanEvent);
+    }
+
+    @Override
+    public <T> Optional<SpanEvent> onConsumerSpanStart(TracingRequest tracingRequest, InjectService<T> injectService,
+        T carrier) {
+        if (!isTracing) {
+            return Optional.empty();
+        }
+        Optional<SpanEvent> spanEventOptional = configureSpanEvent(tracingRequest);
+        if (!spanEventOptional.isPresent()) {
+            return spanEventOptional;
+        }
+        SpanEvent spanEvent = spanEventOptional.get();
+        SpanEventContext spanEventContext = threadLocal.get();
+        spanEventContext.configNextSpanIdPrefix();
+        injectService.addToCarrier(spanEvent, carrier);
+        return Optional.of(spanEvent);
+    }
+
+    private Optional<SpanEvent> configureSpanEvent(TracingRequest tracingRequest) {
+        SpanEventContext spanEventContext = threadLocal.get();
+
+        // 当前Span个数已经超过当前层能采集的最大值，需要清空ThreadLocal不再采集，防止内存泄露
+        if (spanEventContext == null || spanEventContext.getSpanIdCount().get() > MAX_SPAN_EVENT_COUNT) {
+            threadLocal.remove();
+            return Optional.empty();
+        }
+        spanEventContext.addChildrenSpan();
+        SpanEvent spanEvent = spanEventContext.getSpanEvent();
+        spanEvent.setStartTime(System.currentTimeMillis());
+        spanEvent.setClassName(tracingRequest.getClassName());
+        spanEvent.setMethod(tracingRequest.getMethod());
+        return Optional.of(spanEvent);
+    }
+
+    @Override
+    public void onSpanFinally() {
+        if (!isTracing) {
+            return;
+        }
+        SpanEventContext spanEventContext = threadLocal.get();
+        if (spanEventContext == null) {
+            return;
+        }
+        SpanEvent spanEvent = spanEventContext.getSpanEvent();
+        spanEvent.setEndTime(System.currentTimeMillis());
+        sendSpanEvent(spanEvent);
+
+        // 发送完SpanEvent数据后，需要将当前上下文中存放的SpanEvent置为当前Span的父Span
+        if (spanEvent.getParentSpan() != null) {
+            spanEventContext.setSpanEvent(spanEvent.getParentSpan());
+        }
+    }
+
+    @Override
+    public Optional<SpanEvent> onSpanError(Throwable throwable) {
+        if (!isTracing) {
+            return Optional.empty();
+        }
+        SpanEventContext spanEventContext = threadLocal.get();
+        if (spanEventContext == null) {
+            return Optional.empty();
+        }
+        SpanEvent spanEvent = spanEventContext.getSpanEvent();
+        spanEvent.setError(true);
+        spanEvent.setErrorInfo(throwable.getMessage());
+        return Optional.of(spanEvent);
+    }
+
+    /**
+     * 通过SpanId来限制采样深度
+     *
+     * @param tracingRequest 调用链路追踪生命周期时需要传入的参数
+     */
+    private boolean filterSpanDepth(TracingRequest tracingRequest) {
+        // 检查spanId长度 大于100忽略
+        String spanIdPrefix = tracingRequest.getSpanIdPrefix();
+        if (spanIdPrefix != null && spanIdPrefix.length() > MAX_SPAN_EVENT_DEPTH) {
+            LOGGER.info(String.format(Locale.ROOT, "SpanId is too long, discard this span : [%s]",
+                JSON.toJSONString(tracingRequest, SerializerFeature.WriteMapNullValue)));
+            return false;
+        }
+        return true;
+    }
+
+    private void sendSpanEvent(SpanEvent spanEvent) {
+        tracingSender.offerSpanEvent(spanEvent);
+    }
+}

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/service/tracing/common/SourceInfo.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/service/tracing/common/SourceInfo.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.huawei.sermant.core.service.tracing.common;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 描述上一工作单元信息
+ *
+ * @author luanwenfei
+ * @since 2022-03-01
+ */
+@Getter
+@Setter
+@Builder
+public class SourceInfo {
+    private String address;
+
+    private String className;
+
+    private String method;
+}

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/service/tracing/common/SpanEvent.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/service/tracing/common/SpanEvent.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.huawei.sermant.core.service.tracing.common;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Span实体数据
+ *
+ * @author luanwenfei
+ * @since 2022-02-28
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class SpanEvent {
+    private String traceId;
+
+    private String spanId;
+
+    private String parentSpanId;
+
+    private transient String spanIdPrefix;
+
+    /**
+     * 下一进程的spanIdPrefix
+     */
+    private transient String nextSpanIdPrefix;
+
+    private String className;
+
+    private String method;
+
+    private transient SpanEvent parentSpan;
+
+    /**
+     * Span所标识工作单元执行的操作描述
+     */
+    private String operationDescription;
+
+    /**
+     * Span所标识工作单元的类型 mysql、kafka、http等
+     */
+    private String type;
+
+    private long startTime;
+
+    private long endTime;
+
+    private boolean isError;
+
+    private String errorInfo;
+
+    /**
+     * Span所标识工作单元是否为异步
+     */
+    private boolean isAsync;
+
+    /**
+     * 调用当前Span所标识工作单元的节点信息
+     */
+    private SourceInfo sourceInfo;
+
+    /**
+     * Span所标识工作单元调用的目的地的节点信息
+     */
+    private TargetInfo targetInfo;
+
+    private Map<String, String> tags = new LinkedHashMap<>();
+
+    /**
+     * 通过ParentSpan创建ChildrenSpan
+     *
+     * @param spanEvent ParentSpan
+     */
+    public SpanEvent(SpanEvent spanEvent) {
+        this.parentSpan = spanEvent;
+        this.traceId = spanEvent.getTraceId();
+        this.parentSpanId = spanEvent.getSpanId();
+        this.spanIdPrefix = spanEvent.getSpanIdPrefix();
+    }
+
+    /**
+     * 为Span添加标签
+     *
+     * @param key   key
+     * @param value value
+     */
+    public void addTag(String key, String value) {
+        if (key == null || value == null) {
+            return;
+        }
+        this.tags.put(key, value);
+    }
+}

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/service/tracing/common/SpanEventContext.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/service/tracing/common/SpanEventContext.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.huawei.sermant.core.service.tracing.common;
+
+import com.huawei.sermant.core.utils.TracingUtils;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import org.apache.commons.lang.StringUtils;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * 存放SpanEvent、Span计数器及其分支计数器
+ *
+ * @author luanwenfei
+ * @since 2022-03-03
+ */
+@Getter
+@Setter
+public class SpanEventContext {
+    private static final String SPAN_ID_SEPARATOR = "-";
+    SpanEvent spanEvent = new SpanEvent();
+
+    /**
+     * 当前已有span的计数
+     */
+    private AtomicInteger spanIdCount = new AtomicInteger(0);
+
+    /**
+     * 向其他进程调用的计数
+     */
+    private AtomicInteger nextSpanIdCount = new AtomicInteger(0);
+
+    /**
+     * 通过TracingRequest创建SpanEventContext
+     *
+     * @param tracingRequest 传递Span信息
+     */
+    public SpanEventContext(TracingRequest tracingRequest) {
+        checkAndSetTraceId(tracingRequest.getTraceId());
+        checkAndSetSpanId(tracingRequest.getSpanIdPrefix());
+        this.spanEvent.setParentSpanId(tracingRequest.getParentSpanId());
+        this.spanEvent.setSpanIdPrefix(tracingRequest.getSpanIdPrefix());
+        this.spanEvent.setClassName(tracingRequest.getClassName());
+        this.spanEvent.setMethod(tracingRequest.getMethod());
+        this.spanEvent.setSourceInfo(tracingRequest.getSourceInfo());
+    }
+
+    private void checkAndSetTraceId(String traceId) {
+        // 校验数据为透传链路 还是 新建链路，如果traceId为空则需要新建链路并生成traceId
+        if (StringUtils.isBlank(traceId)) {
+            this.spanEvent.setTraceId(TracingUtils.generateTraceId());
+        } else {
+            this.spanEvent.setTraceId(traceId);
+        }
+    }
+
+    private void checkAndSetSpanId(String spanIdPrefix) {
+        // 校验SpanId前缀是否为空，如果没有前缀则代表当前深度为第一层需要不需要添加前缀
+        if (StringUtils.isBlank(spanIdPrefix)) {
+            this.spanEvent.setSpanId(String.valueOf(this.spanIdCount.getAndIncrement()));
+        } else {
+            this.spanEvent.setSpanId(spanIdPrefix + SPAN_ID_SEPARATOR + this.spanIdCount.getAndIncrement());
+        }
+    }
+
+    /**
+     * 当触发非onEntry事件时添加的span均为子span
+     */
+    public void addChildrenSpan() {
+        this.spanEvent = new SpanEvent(this.spanEvent);
+        this.spanEvent
+            .setSpanId(this.spanEvent.getSpanIdPrefix() + SPAN_ID_SEPARATOR + this.spanIdCount.getAndIncrement());
+    }
+
+    /**
+     * 配置下一进程的spanIdPrefix
+     */
+    public void configNextSpanIdPrefix() {
+        this.spanEvent.setNextSpanIdPrefix(
+            this.spanEvent.getSpanId() + SPAN_ID_SEPARATOR + this.nextSpanIdCount.getAndIncrement());
+    }
+}

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/service/tracing/common/TargetInfo.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/service/tracing/common/TargetInfo.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.huawei.sermant.core.service.tracing.common;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 被调用的目的节点信息
+ *
+ * @author luanwenfei
+ * @since 2022-03-01
+ */
+@Getter
+@Setter
+@Builder
+public class TargetInfo {
+    private String address;
+
+    private String className;
+
+    private String method;
+}

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/service/tracing/common/TracingRequest.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/service/tracing/common/TracingRequest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.huawei.sermant.core.service.tracing.common;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 调用链路追踪生命周期时需要传入的参数
+ *
+ * @author luanwenfei
+ * @since 2022-03-01
+ */
+@Getter
+@Setter
+public class TracingRequest {
+    private String traceId;
+
+    private String parentSpanId;
+
+    /**
+     * 当前进程生成SpanId的前缀
+     */
+    private String spanIdPrefix;
+
+    private String className;
+
+    private String method;
+
+    /**
+     * SpanContext的来源信息
+     */
+    private SourceInfo sourceInfo;
+
+    private TargetInfo targetInfo;
+
+    /**
+     * 构造函数
+     *
+     * @param  traceId traceId
+     * @param parentSpanId parentSpanId
+     * @param spanIdPrefix spanIdPrefix
+     * @param className className
+     * @param method method
+     */
+    public TracingRequest(String traceId, String parentSpanId, String spanIdPrefix, String className, String method) {
+        this.traceId = traceId;
+        this.parentSpanId = parentSpanId;
+        this.spanIdPrefix = spanIdPrefix;
+        this.className = className;
+        this.method = method;
+    }
+}

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/service/tracing/sender/TracingMessage.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/service/tracing/sender/TracingMessage.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.huawei.sermant.core.service.tracing.sender;
+
+import com.huawei.sermant.core.service.tracing.common.SpanEvent;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 向后端发送的调用链信息
+ *
+ * @author luanwenfei
+ * @since 2022-03-07
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+public class TracingMessage {
+    private String messageId;
+
+    private TracingMessageHeader header;
+
+    private SpanEvent body;
+}

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/service/tracing/sender/TracingMessageHeader.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/service/tracing/sender/TracingMessageHeader.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.huawei.sermant.core.service.tracing.sender;
+
+import lombok.Builder;
+
+/**
+ * 链路追踪向后端发送数据的头部（应用信息、节点信息）
+ *
+ * @author luanwenfei
+ * @since 2022-03-07
+ */
+@Builder
+public class TracingMessageHeader {
+    private String instanceId;
+
+    private String appId;
+}

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/service/tracing/sender/TracingSender.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/service/tracing/sender/TracingSender.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.huawei.sermant.core.service.tracing.sender;
+
+import com.huawei.sermant.core.common.LoggerFactory;
+import com.huawei.sermant.core.service.ServiceManager;
+import com.huawei.sermant.core.service.send.GatewayClient;
+import com.huawei.sermant.core.service.tracing.common.SpanEvent;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.serializer.SerializerFeature;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.logging.Logger;
+
+/**
+ * 链路追踪消息发送器
+ *
+ * @author luanwenfei
+ * @since 2022-03-04
+ */
+public class TracingSender {
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
+    private static final int TRACING_DATA_TYPE = 10;
+
+    private static final int MAX_SPAN_EVENT_COUNT = 512;
+
+    private static final long TRACING_SENDER_MINIMAL_INTERVAL = 1000L;
+
+    private static final long STOP_TIME_OUT = 3000L;
+
+    private static final ArrayBlockingQueue<SpanEvent> SPAN_EVENT_DATA_QUEUE =
+        new ArrayBlockingQueue<>(MAX_SPAN_EVENT_COUNT);
+
+    private static final ExecutorService EXECUTOR =
+        Executors.newSingleThreadExecutor(runnable -> new Thread(runnable, "tracing-sender-thread"));
+
+    private static TracingSender tracingSender = null;
+
+    private GatewayClient gatewayClient;
+
+    /**
+     * 当前服务开启和关闭的标记位
+     */
+    private boolean isSending;
+
+    private TracingSender() {
+    }
+
+    /**
+     * 获取TracingSender单例
+     *
+     * @return TracingSender单例
+     */
+    public static synchronized TracingSender getInstance() {
+        if (tracingSender == null) {
+            tracingSender = new TracingSender();
+        }
+        return tracingSender;
+    }
+
+    /**
+     * Starting tracingSender.
+     */
+    public void start() {
+        if (this.isSending) {
+            LOGGER.info("TracingSender has started.");
+            return;
+        }
+        this.isSending = true;
+        gatewayClient = ServiceManager.getService(GatewayClient.class);
+        EXECUTOR.execute(new SpanEventSendThread());
+    }
+
+    /**
+     * Stopping tracingSender.
+     */
+    public void stop() {
+        if (!this.isSending) {
+            LOGGER.info("TracingSender has stopped.");
+        }
+        stopSoft(STOP_TIME_OUT);
+        this.isSending = false;
+    }
+
+    /**
+     * 检查阻塞队列、阻塞队列为空或者等待超时后关闭
+     *
+     * @param timeOut 超时时间
+     */
+    public void stopSoft(long timeOut) {
+        long timeDuring = 0L;
+        while (!SPAN_EVENT_DATA_QUEUE.isEmpty() && timeDuring < timeOut) {
+            try {
+                Thread.sleep(TRACING_SENDER_MINIMAL_INTERVAL);
+                timeDuring += TRACING_SENDER_MINIMAL_INTERVAL;
+            } catch (InterruptedException e) {
+                LOGGER.severe(String.format(Locale.ROOT,
+                    "Exception [%s] occurs for [%s] when waiting to stop TracingSender service. ", e.getClass(),
+                    e.getMessage()));
+            }
+        }
+        SPAN_EVENT_DATA_QUEUE.clear();
+        this.isSending = false;
+    }
+
+    /**
+     * 向阻塞队列里添加SpanEvent 发送数据线程获取后发送到backend
+     *
+     * @param spanEvent span数据
+     */
+    public void offerSpanEvent(SpanEvent spanEvent) {
+        if (spanEvent == null) {
+            return;
+        }
+        boolean isSuccessful = SPAN_EVENT_DATA_QUEUE.offer(spanEvent);
+        if (!isSuccessful) {
+            LOGGER.warning("Failed to offer spanEvent.");
+        }
+    }
+
+    /**
+     * 链路追踪消息发送线程
+     *
+     * @author luanwenfei
+     * @since 2022-03-04
+     */
+    private class SpanEventSendThread extends Thread {
+        @Override
+        public void run() {
+            LOGGER.info("TracingSender started.");
+            while (isSending) {
+                Optional<TracingMessage> tracingMessage = buildTracingMessage();
+                if (!tracingMessage.isPresent()) {
+                    // 如果没有获取到SpanEvent,等待一段时间后再次执行
+                    try {
+                        Thread.sleep(TRACING_SENDER_MINIMAL_INTERVAL);
+                    } catch (InterruptedException e) {
+                        LOGGER.severe(String.format(Locale.ROOT, "Exception [%s] occurs for [%s] when waiting queue. ",
+                            e.getClass(), e.getMessage()));
+                    }
+                    continue;
+                }
+                sendMessage(tracingMessage.get());
+            }
+            LOGGER.info("TracingSender stopped.");
+        }
+
+        private Optional<TracingMessage> buildTracingMessage() {
+            SpanEvent spanEvent = SPAN_EVENT_DATA_QUEUE.poll();
+            if (spanEvent == null) {
+                LOGGER.warning("SpanEvent is null.");
+                return Optional.empty();
+            }
+
+            // 节点信息待整改配置后获取
+            TracingMessageHeader tracingMessageHeader = TracingMessageHeader.builder().build();
+            return Optional.of(new TracingMessage(spanEvent.getTraceId(), tracingMessageHeader, spanEvent));
+        }
+
+        private void sendMessage(TracingMessage tracingMessage) {
+            LOGGER.info(String.format(Locale.ROOT, "Sending tracing message traceId : [%s] , spanId : [%s] .",
+                tracingMessage.getBody().getTraceId(), tracingMessage.getBody().getSpanId()));
+            String serializedMessage = JSON.toJSONString(tracingMessage, SerializerFeature.WriteMapNullValue);
+            gatewayClient.send(serializedMessage.getBytes(StandardCharsets.UTF_8), TRACING_DATA_TYPE);
+        }
+    }
+}

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/utils/TracingUtils.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/utils/TracingUtils.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.huawei.sermant.core.utils;
+
+import java.util.UUID;
+
+/**
+ * 链路追踪工具类
+ *
+ * @author luanwenfei
+ * @since 2022-03-02
+ */
+public class TracingUtils {
+    private TracingUtils() {
+    }
+
+    /**
+     * 生成TraceId
+     *
+     * @return TraceId
+     */
+    public static String generateTraceId() {
+        return UUID.randomUUID().toString();
+    }
+}

--- a/sermant-agentcore/sermant-agentcore-core/src/main/resources/META-INF/services/com.huawei.sermant.core.service.BaseService
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/resources/META-INF/services/com.huawei.sermant.core.service.BaseService
@@ -1,3 +1,4 @@
 com.huawei.sermant.core.service.heartbeat.HeartbeatServiceImpl
 com.huawei.sermant.core.service.send.NettyGatewayClient
 com.huawei.sermant.core.service.dynamicconfig.BufferedDynamicConfigService
+com.huawei.sermant.core.service.tracing.TracingServiceImpl

--- a/sermant-agentcore/sermant-agentcore-core/src/test/java/com/huawei/sermant/core/service/tracing/TracingServiceImplTest.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/test/java/com/huawei/sermant/core/service/tracing/TracingServiceImplTest.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.huawei.sermant.core.service.tracing;
+
+import com.huawei.sermant.core.lubanops.bootstrap.log.LogFactory;
+import com.huawei.sermant.core.service.ServiceManager;
+import com.huawei.sermant.core.service.send.GatewayClient;
+import com.huawei.sermant.core.service.send.NettyGatewayClient;
+import com.huawei.sermant.core.service.tracing.common.SpanEvent;
+import com.huawei.sermant.core.service.tracing.common.TracingRequest;
+import com.huawei.sermant.core.utils.TracingUtils;
+
+import org.apache.commons.lang.RandomStringUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * TracingService UT
+ *
+ * @author luanwenfei
+ * @since 2022-03-09
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class TracingServiceImplTest {
+    private static final String TRACE_ID = "TRACE_ID";
+
+    private static final String PARENT_SPAN_ID = "PARENT_SPAN_ID";
+
+    private static final String SPAN_ID_PREFIX = "SPAN_ID_PREFIX";
+
+    private static final String INIT_PARENT_SPAN_ID = "0";
+
+    private static final String INIT_SPAN_ID_PREFIX = "0-0";
+
+    private static final String INIT_SPAN_ID = "0-0-0";
+
+    private static final String SPAN_ERROR_MESSAGE = "OnSpanError";
+
+    private static final int STRING_SIZE = 101;
+
+    Map<String, String> header = new HashMap<>();
+
+    ExtractService<Map<String, String>> extractService;
+
+    InjectService<Map<String, String>> injectService;
+
+    /**
+     * 初始化
+     */
+    @Before
+    public void setUp() {
+        LogFactory.setLogger(java.util.logging.Logger.getLogger("Test"));
+
+        header.put(TRACE_ID, "");
+        header.put(PARENT_SPAN_ID, "");
+        header.put(SPAN_ID_PREFIX, "");
+
+        // 实现提取接口
+        extractService = (tracingRequest, carrier) -> {
+            tracingRequest.setTraceId(carrier.get(TRACE_ID));
+            tracingRequest.setParentSpanId(carrier.get(PARENT_SPAN_ID));
+            tracingRequest.setSpanIdPrefix(carrier.get(SPAN_ID_PREFIX));
+        };
+
+        // 实现注入接口
+        injectService = (spanEvent, carrier) -> {
+            carrier.put(TRACE_ID, spanEvent.getTraceId());
+            carrier.put(PARENT_SPAN_ID, spanEvent.getSpanId());
+            carrier.put(SPAN_ID_PREFIX, spanEvent.getNextSpanIdPrefix());
+        };
+
+    }
+
+    /**
+     * 普通span场景测试
+     */
+    @Test
+    public void onNormalSpanStart() {
+        try (MockedStatic<ServiceManager> mockedStatic = Mockito.mockStatic(ServiceManager.class)) {
+            mockedStatic.when(() -> ServiceManager.getService(GatewayClient.class))
+                .thenReturn(new NettyGatewayClient());
+            TracingServiceImpl tracingService = new TracingServiceImpl();
+
+            // Service is stopped.
+            tracingService.stop();
+            TracingRequest tracingRequest = new TracingRequest("", "", "", "", "");
+            Assert.assertFalse(tracingService.onNormalSpanStart(tracingRequest).isPresent());
+
+            // SpanEventContext is null.
+            tracingService.start();
+            Assert.assertFalse(tracingService.onNormalSpanStart(tracingRequest).isPresent());
+
+            // The normal condition.
+            String traceId = TracingUtils.generateTraceId();
+            header.put(TRACE_ID, traceId);
+            header.put(PARENT_SPAN_ID, INIT_PARENT_SPAN_ID);
+            header.put(SPAN_ID_PREFIX, INIT_SPAN_ID_PREFIX);
+            tracingService.onProviderSpanStart(tracingRequest, extractService, header);
+            tracingService.onSpanFinally();
+            Optional<SpanEvent> spanEventOptional = tracingService.onNormalSpanStart(tracingRequest);
+            Assert.assertTrue(spanEventOptional.isPresent());
+            Assert.assertEquals(traceId, spanEventOptional.get().getTraceId());
+            Assert.assertEquals("0-0-1", spanEventOptional.get().getSpanId());
+            Assert.assertEquals(INIT_SPAN_ID, spanEventOptional.get().getParentSpanId());
+            tracingService.onSpanFinally();
+
+            // The second children span.
+            spanEventOptional = tracingService.onNormalSpanStart(tracingRequest);
+            Assert.assertTrue(spanEventOptional.isPresent());
+            Assert.assertEquals(traceId, spanEventOptional.get().getTraceId());
+            Assert.assertEquals("0-0-2", spanEventOptional.get().getSpanId());
+            Assert.assertEquals(INIT_SPAN_ID, spanEventOptional.get().getParentSpanId());
+            tracingService.onSpanFinally();
+            tracingService.stop();
+        }
+    }
+
+    /**
+     * Provider场景span测试
+     */
+    @Test
+    public void onProviderSpanStart() {
+        try (MockedStatic<ServiceManager> mockedStatic = Mockito.mockStatic(ServiceManager.class)) {
+            mockedStatic.when(() -> ServiceManager.getService(GatewayClient.class))
+                .thenReturn(new NettyGatewayClient());
+            TracingServiceImpl tracingService = new TracingServiceImpl();
+
+            // Service is stopped.
+            tracingService.stop();
+            TracingRequest tracingRequest = new TracingRequest("", "", "", "", "");
+            Assert.assertFalse(tracingService.onProviderSpanStart(tracingRequest, extractService, header).isPresent());
+
+            // SpanIdPrefix is too long.
+            tracingService.start();
+            String spanIdPrefix = RandomStringUtils.randomNumeric(STRING_SIZE);
+            header.put(SPAN_ID_PREFIX, spanIdPrefix);
+            Assert.assertFalse(tracingService.onProviderSpanStart(tracingRequest, extractService, header).isPresent());
+            tracingService.stop();
+
+            // The normal condition root span.
+            tracingService.start();
+            header.put(SPAN_ID_PREFIX, "");
+            Optional<SpanEvent> spanEventOptional =
+                tracingService.onProviderSpanStart(tracingRequest, extractService, header);
+            Assert.assertTrue(spanEventOptional.isPresent());
+            Assert.assertFalse(spanEventOptional.get().getTraceId().isEmpty());
+            Assert.assertEquals(INIT_PARENT_SPAN_ID, spanEventOptional.get().getSpanId());
+            Assert.assertEquals("", spanEventOptional.get().getParentSpanId());
+            tracingService.stop();
+
+            // The normal condition children span
+            tracingService.start();
+            String traceId = TracingUtils.generateTraceId();
+            header.put(TRACE_ID, traceId);
+            header.put(PARENT_SPAN_ID, INIT_PARENT_SPAN_ID);
+            header.put(SPAN_ID_PREFIX, INIT_SPAN_ID_PREFIX);
+            spanEventOptional = tracingService.onProviderSpanStart(tracingRequest, extractService, header);
+            Assert.assertTrue(spanEventOptional.isPresent());
+            Assert.assertEquals(traceId, spanEventOptional.get().getTraceId());
+            Assert.assertEquals(INIT_SPAN_ID, spanEventOptional.get().getSpanId());
+            Assert.assertEquals(INIT_PARENT_SPAN_ID, spanEventOptional.get().getParentSpanId());
+            tracingService.stop();
+        }
+    }
+
+    /**
+     * consumer场景span测试
+     */
+    @Test
+    public void onConsumerSpanStart() {
+        try (MockedStatic<ServiceManager> mockedStatic = Mockito.mockStatic(ServiceManager.class)) {
+            mockedStatic.when(() -> ServiceManager.getService(GatewayClient.class))
+                .thenReturn(new NettyGatewayClient());
+            TracingServiceImpl tracingService = new TracingServiceImpl();
+
+            // Service is stopped.
+            tracingService.stop();
+            TracingRequest tracingRequest = new TracingRequest("", "", "", "", "");
+            Assert.assertFalse(tracingService.onConsumerSpanStart(tracingRequest, injectService, header).isPresent());
+
+            // SpanEventContext is null.
+            tracingService.start();
+            Assert.assertFalse(tracingService.onConsumerSpanStart(tracingRequest, injectService, header).isPresent());
+
+            // The normal condition.
+            String traceId = TracingUtils.generateTraceId();
+            header.put(TRACE_ID, traceId);
+            header.put(PARENT_SPAN_ID, INIT_PARENT_SPAN_ID);
+            header.put(SPAN_ID_PREFIX, INIT_SPAN_ID_PREFIX);
+            tracingService.onProviderSpanStart(tracingRequest, extractService, header);
+            tracingService.onSpanFinally();
+            Optional<SpanEvent> spanEventOptional =
+                tracingService.onConsumerSpanStart(tracingRequest, injectService, header);
+            Assert.assertTrue(spanEventOptional.isPresent());
+            Assert.assertEquals("0-0-1", spanEventOptional.get().getSpanId());
+            Assert.assertEquals(INIT_SPAN_ID, spanEventOptional.get().getParentSpanId());
+            Assert.assertEquals(traceId, header.get(TRACE_ID));
+            Assert.assertEquals("0-0-1-0", header.get(SPAN_ID_PREFIX));
+            tracingService.onSpanFinally();
+            tracingService.stop();
+        }
+    }
+
+    /**
+     * span中出现错误场景测试
+     */
+    @Test
+    public void onSpanError() {
+        try (MockedStatic<ServiceManager> mockedStatic = Mockito.mockStatic(ServiceManager.class)) {
+            mockedStatic.when(() -> ServiceManager.getService(GatewayClient.class))
+                .thenReturn(new NettyGatewayClient());
+            TracingServiceImpl tracingService = new TracingServiceImpl();
+
+            // Service is stopped.
+            tracingService.stop();
+            Assert.assertFalse(tracingService.onSpanError(new Throwable(SPAN_ERROR_MESSAGE)).isPresent());
+
+            // SpanEventContext is null.
+            tracingService.start();
+            Assert.assertFalse(tracingService.onSpanError(new Throwable(SPAN_ERROR_MESSAGE)).isPresent());
+
+            // The normal condition.
+            String traceId = TracingUtils.generateTraceId();
+            header.put(TRACE_ID, traceId);
+            header.put(PARENT_SPAN_ID, INIT_PARENT_SPAN_ID);
+            header.put(SPAN_ID_PREFIX, INIT_SPAN_ID_PREFIX);
+            TracingRequest tracingRequest = new TracingRequest("", "", "", "", "");
+            tracingService.onProviderSpanStart(tracingRequest, extractService, header);
+            Optional<SpanEvent> spanEventOptional = tracingService.onSpanError(new Throwable(SPAN_ERROR_MESSAGE));
+            Assert.assertTrue(spanEventOptional.isPresent());
+            Assert.assertTrue(spanEventOptional.get().isError());
+            Assert.assertEquals(SPAN_ERROR_MESSAGE, spanEventOptional.get().getErrorInfo());
+            tracingService.onSpanFinally();
+            tracingService.stop();
+        }
+    }
+}

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-demos/pom.xml
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-demos/pom.xml
@@ -11,6 +11,7 @@
         <artifactId>spring-boot-starter-parent</artifactId>
         <groupId>org.springframework.boot</groupId>
         <version>2.5.3</version>
+        <relativePath></relativePath>
     </parent>
     <artifactId>flowcontrol-demos</artifactId>
     <groupId>com.huawei.flowcontrol.demo</groupId>
@@ -24,5 +25,4 @@
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
     </properties>
-
 </project>


### PR DESCRIPTION
【issue号/问题单号/需求单号】#328

【修改内容】在service中新增链路追踪服务

【用例描述】1、provider场景跨度span测试 2、consumer场景跨度span测试 3、内部工作跨度场景span测试

【自测情况】1、静态检查通过；2、门槛用例通过；3、UT行覆盖86%；4、本地自测

【影响范围】1、新增插件时，需要添加链路追踪生命周期 2、需更新链路追踪服务代码