### PR TITLE
【fix】修复增强启动类加载器加载类会被添加static块导致redefine抛出异常的问题

### DIFF
--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/plugin/agent/BufferedAgentBuilder.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huawei/sermant/core/plugin/agent/BufferedAgentBuilder.java
@@ -263,6 +263,7 @@ public class BufferedAgentBuilder {
         for (BuilderAction action : actions) {
             builder = action.process(builder);
         }
+        builder.disableClassFormatChanges();
         return builder.installOn(instrumentation);
     }
 


### PR DESCRIPTION
【issue号/问题单号/需求单号】#494

【修改内容】1、修复增强启动类加载器加载类会被添加static块导致redefine抛出异常的问题

【用例描述】不涉及

【自测情况】1、本地静态检查清理情况；2、基线测试用例已过

【影响范围】不涉及