### PR TITLE
【BUG】修复没有kafka服务时，backend数据处理阻塞问题

### DIFF
--- a/sermant-backend/src/main/java/com/huawei/sermant/backend/server/NettyServer.java
+++ b/sermant-backend/src/main/java/com/huawei/sermant/backend/server/NettyServer.java
@@ -121,7 +121,8 @@ public class NettyServer {
                             pipeline.addLast(new ProtobufDecoder(Message.NettyMessage.getDefaultInstance()));
                             pipeline.addLast(new ProtobufVarint32LengthFieldPrepender());
                             pipeline.addLast(new ProtobufEncoder());
-                            pipeline.addLast(new ServerHandler(producer, consumer, topicMapping));
+                            pipeline.addLast(new ServerHandler(producer, consumer, topicMapping,
+                                    conf.getIsHeartbeatCache()));
                         }
                     });
 

--- a/sermant-backend/src/test/java/com/huawei/sermant/backend/NettyServerTest.java
+++ b/sermant-backend/src/test/java/com/huawei/sermant/backend/NettyServerTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 public class NettyServerTest {
     private KafkaProducer<String, byte[]> producer;
     private KafkaConsumer<String, String> consumer;
+    private String isHeartBeatCache = "false";
 
     private DataTypeTopicMapping topicMapping;
 
@@ -31,7 +32,8 @@ public class NettyServerTest {
      */
     @Test
     public void testWriteInBound() {
-        EmbeddedChannel embeddedChannel = new EmbeddedChannel(new ServerHandler(producer, consumer, topicMapping));
+        EmbeddedChannel embeddedChannel = new EmbeddedChannel(
+                new ServerHandler(producer, consumer, topicMapping, isHeartBeatCache));
         boolean writeInbound = embeddedChannel.writeInbound(Message.ServiceData.newBuilder().build());
         Assert.assertTrue(writeInbound);
         Assert.assertTrue(embeddedChannel.finish());
@@ -45,7 +47,8 @@ public class NettyServerTest {
      */
     @Test
     public void testWriteOutBound() {
-        EmbeddedChannel embeddedChannel = new EmbeddedChannel(new ServerHandler(producer, consumer, topicMapping));
+        EmbeddedChannel embeddedChannel = new EmbeddedChannel(
+                new ServerHandler(producer, consumer, topicMapping, isHeartBeatCache));
         boolean writeOutBound = embeddedChannel.writeOutbound(Message.ServiceData.newBuilder().build());
         Assert.assertTrue(writeOutBound);
         Assert.assertTrue(embeddedChannel.finish());


### PR DESCRIPTION
【issue号/问题单号/需求单号】#506

【修改内容】修复没有kafka服务时，backend数据处理阻塞问题

【用例描述】不需测试用例

【自测情况】本地静态检查通过

【影响范围】用户在使用sermant时，bakcend中开启心跳缓存，则不用必须启动kafka服务。
