### PR TITLE
【fix】修复测试用例发现的部分问题 

### DIFF
--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/adapte/cse/ResolverManager.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/adapte/cse/ResolverManager.java
@@ -57,8 +57,23 @@ public enum ResolverManager {
      */
     private final Converter<String, Map<String, Object>> mapConverter = new YamlConverter<>(Map.class);
 
+    /**
+     * 解析器配置前缀集合
+     */
+    private Set<String> resolverConfigPrefix;
+
     ResolverManager() {
         loadSpiResolvers();
+    }
+
+    /**
+     * 判断该键是否为流控规则配置
+     *
+     * @param key 配置键
+     * @return 是否符合要求的配置
+     */
+    public boolean isTarget(String key) {
+        return resolverConfigPrefix.stream().anyMatch(key::startsWith);
     }
 
     /**
@@ -77,7 +92,7 @@ public enum ResolverManager {
      * @param isForDelete 是否是为了移除场景
      */
     public void resolve(Map<String, String> rulesMap, boolean isForDelete) {
-        final Set<String> configKeyPrefixDic = resolversMap.keySet();
+        final Set<String> configKeyPrefixDic = resolverConfigPrefix;
         for (Map.Entry<String, String> ruleEntity : rulesMap.entrySet()) {
             final String key = ruleEntity.getKey();
             final String value = ruleEntity.getValue();
@@ -213,5 +228,6 @@ public enum ResolverManager {
             }
             resolversMap.put(configKeyPrefix, resolver);
         }
+        resolverConfigPrefix = resolversMap.keySet();
     }
 }

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/adapte/cse/match/BusinessMatcher.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/adapte/cse/match/BusinessMatcher.java
@@ -45,7 +45,7 @@ public class BusinessMatcher extends Configurable implements Matcher {
     private List<RequestMatcher> matches;
 
     @Override
-    public boolean isValid() {
+    public boolean isInValid() {
         return matches == null || matches.isEmpty();
     }
 

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/adapte/cse/resolver/AbstractResolver.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/adapte/cse/resolver/AbstractResolver.java
@@ -153,7 +153,7 @@ public abstract class AbstractResolver<T extends Configurable> {
         rule.setName(businessKey);
 
         // 4、判断规则是否合法
-        if (rule.isValid()) {
+        if (rule.isInValid()) {
             return Optional.empty();
         }
         if (!isServicesMatch(rule.getServices())) {

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/adapte/cse/rule/AbstractRule.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/adapte/cse/rule/AbstractRule.java
@@ -44,7 +44,7 @@ public abstract class AbstractRule extends Configurable implements Rule {
     private static final String DURATION_PREFIX = "PT";
 
     @Override
-    public boolean isValid() {
+    public boolean isInValid() {
         return StringUtils.isEmpty(name);
     }
 

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/adapte/cse/rule/BulkheadRule.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/adapte/cse/rule/BulkheadRule.java
@@ -50,14 +50,14 @@ public class BulkheadRule extends AbstractRule {
     private long parsedMaxWaitDuration = DEFAULT_MAX_WAIT_DURATION_MS;
 
     @Override
-    public boolean isValid() {
+    public boolean isInValid() {
         if (maxConcurrentCalls < 0) {
             return true;
         }
         if (parsedMaxWaitDuration < 0) {
             return true;
         }
-        return super.isValid();
+        return super.isInValid();
     }
 
     public long getParsedMaxWaitDuration() {

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/adapte/cse/rule/CircuitBreakerRule.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/adapte/cse/rule/CircuitBreakerRule.java
@@ -137,7 +137,7 @@ public class CircuitBreakerRule extends AbstractRule {
     private long parsedSlidingWindowSize = DEFAULT_SLIDING_WINDOW_SIZE;
 
     @Override
-    public boolean isValid() {
+    public boolean isInValid() {
         if (failureRateThreshold > MAX_PERCENT || failureRateThreshold <= MIN_PERCENT) {
             return false;
         }
@@ -154,7 +154,7 @@ public class CircuitBreakerRule extends AbstractRule {
             return false;
         }
 
-        return super.isValid();
+        return super.isInValid();
     }
 
     public float getFailureRateThreshold() {

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/adapte/cse/rule/Configurable.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/adapte/cse/rule/Configurable.java
@@ -45,7 +45,7 @@ public abstract class Configurable {
      *
      * @return 是否合法
      */
-    public abstract boolean isValid();
+    public abstract boolean isInValid();
 
     public String getName() {
         return name;

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/adapte/cse/rule/RateLimitingRule.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/adapte/cse/rule/RateLimitingRule.java
@@ -65,8 +65,8 @@ public class RateLimitingRule extends AbstractRule {
     private int rate = DEFAULT_RATE;
 
     @Override
-    public boolean isValid() {
-        return parsedTimeoutDuration < 0 || parsedLimitRefreshPeriod <= 0 || rate <= 0 || super.isValid();
+    public boolean isInValid() {
+        return parsedTimeoutDuration < 0 || parsedLimitRefreshPeriod <= 0 || rate <= 0 || super.isInValid();
     }
 
     public long getParsedTimeoutDuration() {

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/adapte/cse/rule/RetryRule.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/adapte/cse/rule/RetryRule.java
@@ -90,7 +90,7 @@ public class RetryRule extends AbstractRule {
     /**
      * 需要重试的http status, 逗号分隔
      */
-    private List<String> retryOnResponseStatus = new ArrayList<String>();
+    private List<String> retryOnResponseStatus = new ArrayList<>();
 
     /**
      * 重试策略
@@ -118,7 +118,7 @@ public class RetryRule extends AbstractRule {
     private double randomizationFactor = DEFAULT_RANDOMIZATION_FACTOR;
 
     @Override
-    public boolean isValid() {
+    public boolean isInValid() {
         if (maxAttempts < 1) {
             return true;
         }
@@ -128,7 +128,7 @@ public class RetryRule extends AbstractRule {
         if (parsedInitialInterval < MIN_INITIAL_INTERVAL_MS) {
             return true;
         }
-        return super.isValid();
+        return super.isInValid();
     }
 
     public int getMaxAttempts() {

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-plugin/pom.xml
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-plugin/pom.xml
@@ -100,7 +100,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <artifactId>mockito-inline</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/config/SpringEnvironmentInterceptor.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/config/SpringEnvironmentInterceptor.java
@@ -17,6 +17,7 @@
 
 package com.huawei.flowcontrol.config;
 
+import com.huawei.flowcontrol.common.adapte.cse.ResolverManager;
 import com.huawei.flowcontrol.common.adapte.cse.constants.CseConstants;
 import com.huawei.flowcontrol.common.adapte.cse.entity.CseServiceMeta;
 import com.huawei.flowcontrol.common.config.ConfigConst;
@@ -28,7 +29,16 @@ import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor
 import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
 
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.EnumerablePropertySource;
 import org.springframework.core.env.Environment;
+import org.springframework.core.env.MutablePropertySources;
+import org.springframework.core.env.PropertySource;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * apache dubbo配置拦截
@@ -37,6 +47,14 @@ import org.springframework.core.env.Environment;
  * @since 2022-01-28
  */
 public class SpringEnvironmentInterceptor extends AbstractInterceptor {
+    /**
+     * 标记为bootstrap.run, 该方法当前环境变量未初始化完成, 若有该标记则跳过
+     */
+    private static final String BOOTSTRAP_MARK_CLASS =
+        "org.springframework.cloud.bootstrap.BootstrapImportSelectorConfiguration";
+
+    private final AtomicBoolean isLoadedRule = new AtomicBoolean();
+
     @Override
     public ExecuteContext before(ExecuteContext context) throws Exception {
         return context;
@@ -45,12 +63,15 @@ public class SpringEnvironmentInterceptor extends AbstractInterceptor {
     @Override
     public ExecuteContext after(ExecuteContext context) {
         final Object applicationContext = context.getArguments()[0];
-        if (!(applicationContext instanceof ConfigurableApplicationContext) || CseServiceMeta.getInstance()
-            .isDubboService()) {
+        if (!(applicationContext instanceof ConfigurableApplicationContext) || !canSubscribe(context)) {
+            return context;
+        }
+        Environment environment = ((ConfigurableApplicationContext) applicationContext).getEnvironment();
+        loadRuleFromEnvironment(environment);
+        if (CseServiceMeta.getInstance().isDubboService()) {
             return context;
         }
         final FlowControlConfig pluginConfig = PluginConfigManager.getPluginConfig(FlowControlConfig.class);
-        Environment environment = ((ConfigurableApplicationContext) applicationContext).getEnvironment();
         if (pluginConfig.isUseCseRule() && pluginConfig.isBaseSdk()) {
             CseServiceMeta.getInstance().setProject(environment.getProperty(CseConstants.KEY_SPRING_KIE_PROJECT,
                 CseConstants.DEFAULT_PROJECT));
@@ -71,5 +92,59 @@ public class SpringEnvironmentInterceptor extends AbstractInterceptor {
             CseServiceMeta.getInstance().setServiceName(serviceName);
         }
         return context;
+    }
+
+    /**
+     * 从spring环境变量读取流控策略
+     *
+     * @param environment 环境变量
+     */
+    private void loadRuleFromEnvironment(Environment environment) {
+        if (!(environment instanceof ConfigurableEnvironment)) {
+            return;
+        }
+        ConfigurableEnvironment configurableEnvironment = (ConfigurableEnvironment) environment;
+        if (isLoadedRule.compareAndSet(false, true)) {
+            for (PropertySource<?> next : getPropertySources(configurableEnvironment.getPropertySources())) {
+                loadRuleFromSource((EnumerablePropertySource<?>) next);
+            }
+        }
+    }
+
+    /**
+     * 这里对配置源倒序排序，保证获取的配置优先级与spring一致
+     *
+     * @param propertySources 配置源
+     * @return 倒序后的配置源
+     */
+    private List<PropertySource<?>> getPropertySources(MutablePropertySources propertySources) {
+        final LinkedList<PropertySource<?>> result = new LinkedList<>();
+        propertySources.stream().filter(propertySource -> propertySource instanceof EnumerablePropertySource)
+                .forEach(result::addFirst);
+        return result;
+    }
+
+    private void loadRuleFromSource(EnumerablePropertySource<?> source) {
+        final String[] propertyNames = source.getPropertyNames();
+        for (String propertyName : propertyNames) {
+            if (!ResolverManager.INSTANCE.isTarget(propertyName)) {
+                continue;
+            }
+            ResolverManager.INSTANCE.resolve(propertyName, String.valueOf(source.getProperty(propertyName)), false);
+        }
+    }
+
+    private boolean canSubscribe(ExecuteContext context) {
+        final Object primarySources = context.getMemberFieldValue("primarySources");
+        if (!(primarySources instanceof Set)) {
+            return false;
+        }
+        Set<Class<?>> primaryClasses = (Set<Class<?>>) primarySources;
+        for (Class<?> clazz : primaryClasses) {
+            if (clazz.getName().equals(BOOTSTRAP_MARK_CLASS)) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/declarers/DiscoveryClientDeclarer.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/declarers/DiscoveryClientDeclarer.java
@@ -17,6 +17,7 @@
 package com.huawei.registry.declarers;
 
 import com.huawei.registry.interceptors.DiscoveryClientInterceptor;
+import com.huawei.registry.interceptors.DiscoveryClientServiceInterceptor;
 
 import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
@@ -41,6 +42,11 @@ public class DiscoveryClientDeclarer extends AbstractPluginDeclarer {
      */
     private static final String INTERCEPT_CLASS = DiscoveryClientInterceptor.class.getCanonicalName();
 
+    /**
+     * 服务名拦截
+     */
+    private static final String SERVICE_INTERCEPT_CLASS = DiscoveryClientServiceInterceptor.class.getCanonicalName();
+
     @Override
     public ClassMatcher getClassMatcher() {
         return ClassMatcher.nameEquals(ENHANCE_CLASS);
@@ -49,7 +55,8 @@ public class DiscoveryClientDeclarer extends AbstractPluginDeclarer {
     @Override
     public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
         return new InterceptDeclarer[]{
-            InterceptDeclarer.build(MethodMatcher.nameEquals("getInstances"), INTERCEPT_CLASS)
+            InterceptDeclarer.build(MethodMatcher.nameEquals("getInstances"), INTERCEPT_CLASS),
+            InterceptDeclarer.build(MethodMatcher.nameEquals("getServices"), SERVICE_INTERCEPT_CLASS)
         };
     }
 }

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/interceptors/DiscoveryClientServiceInterceptor.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/interceptors/DiscoveryClientServiceInterceptor.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.registry.interceptors;
+
+import com.huawei.registry.context.RegisterContext;
+import com.huawei.registry.services.RegisterCenterService;
+import com.huawei.registry.support.InstanceInterceptorSupport;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.service.ServiceManager;
+
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 拦截获取服务名列表
+ *
+ * @author zhouss
+ * @since 2021-12-13
+ */
+public class DiscoveryClientServiceInterceptor extends InstanceInterceptorSupport {
+    @Override
+    public ExecuteContext doBefore(ExecuteContext context) {
+        if (isMarked()) {
+            return context;
+        }
+        try {
+            mark();
+            final RegisterCenterService service = ServiceManager.getService(RegisterCenterService.class);
+            final List<String> services = new ArrayList<>(service.getServices());
+            if (isOpenMigration() && RegisterContext.INSTANCE.isAvailable()) {
+                // 合并两个注册中心
+                final DiscoveryClient discoveryClient = (DiscoveryClient) context.getObject();
+                services.addAll(discoveryClient.getServices());
+            }
+            context.skip(services.stream().distinct().collect(Collectors.toList()));
+        } finally {
+            unMark();
+        }
+        return context;
+    }
+
+    @Override
+    protected String getInstanceClassName() {
+        return "";
+    }
+}

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/services/RegisterCenterService.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/services/RegisterCenterService.java
@@ -44,4 +44,11 @@ public interface RegisterCenterService extends PluginService {
      * @return 实例列表
      */
     List<MicroServiceInstance> getServerList(String serviceId);
+
+    /**
+     * 获取服务名列表
+     *
+     * @return 服务列表
+     */
+    List<String> getServices();
 }

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-service/src/main/java/com/huawei/registry/service/client/ScClient.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-service/src/main/java/com/huawei/registry/service/client/ScClient.java
@@ -159,7 +159,8 @@ public class ScClient {
         }
         final List<Microservice> allServices = response.getServices();
         final List<String> allServiceIds =
-            allServices.stream().filter(service -> StringUtils.equals(service.getServiceName(), serviceName))
+            allServices.stream().filter(service -> StringUtils.equals(service.getServiceName(),
+                getRealServiceName(true, serviceName)))
                 .map(Microservice::getServiceId).distinct().collect(Collectors.toList());
         List<MicroserviceInstance> microserviceInstances = new ArrayList<>();
         allServiceIds.forEach(serviceId -> {
@@ -170,6 +171,18 @@ public class ScClient {
             }
         });
         return microserviceInstances;
+    }
+
+    private String getRealServiceName(boolean isAllowCrossApp, String serviceName) {
+        if (!isAllowCrossApp) {
+            return serviceName;
+        }
+        String curServiceName = serviceName;
+        final int index = serviceName.indexOf(ConfigConstants.APP_SERVICE_SEPARATOR);
+        if (index != -1) {
+            curServiceName = serviceName.substring(index + 1);
+        }
+        return curServiceName;
     }
 
     private List<MicroserviceInstance> getInstanceByCurApp(String serviceName) {

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-service/src/main/java/com/huawei/registry/service/impl/RegisterCenterServiceImpl.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-service/src/main/java/com/huawei/registry/service/impl/RegisterCenterServiceImpl.java
@@ -73,6 +73,11 @@ public class RegisterCenterServiceImpl implements RegisterCenterService {
         return RegisterManager.INSTANCE.getServerList(serviceId);
     }
 
+    @Override
+    public List<String> getServices() {
+        return RegisterManager.INSTANCE.getServices();
+    }
+
     private RegisterConfig getRegisterConfig() {
         if (registerConfig == null) {
             registerConfig = PluginConfigManager.getPluginConfig(RegisterConfig.class);

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-service/src/main/java/com/huawei/registry/service/register/Register.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-service/src/main/java/com/huawei/registry/service/register/Register.java
@@ -52,6 +52,13 @@ public interface Register {
     <T extends MicroServiceInstance> List<T> getInstanceList(String serviceId);
 
     /**
+     * 获取服务名列表
+     *
+     * @return 服务名列表
+     */
+    List<String> getServices();
+
+    /**
      * 注册中心类型
      *
      * @return register type

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-service/src/main/java/com/huawei/registry/service/register/RegisterManager.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-service/src/main/java/com/huawei/registry/service/register/RegisterManager.java
@@ -123,4 +123,17 @@ public enum RegisterManager {
         }
         return Collections.emptyList();
     }
+
+    /**
+     * 获取服务名列表
+     *
+     * @return 服务名列表
+     */
+    public List<String> getServices() {
+        final Register register = getRegister();
+        if (register != null) {
+            return register.getServices();
+        }
+        return Collections.emptyList();
+    }
 }

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-service/src/main/java/com/huawei/registry/service/register/ScRegister.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-service/src/main/java/com/huawei/registry/service/register/ScRegister.java
@@ -16,14 +16,24 @@
 
 package com.huawei.registry.service.register;
 
+import com.huawei.registry.config.RegisterConfig;
 import com.huawei.registry.service.client.ScClient;
 
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
+import com.huaweicloud.sermant.core.utils.StringUtils;
+
+import org.apache.servicecomb.service.center.client.exception.OperationException;
+import org.apache.servicecomb.service.center.client.model.Microservice;
 import org.apache.servicecomb.service.center.client.model.MicroserviceInstance;
 import org.apache.servicecomb.service.center.client.model.MicroserviceInstanceStatus;
+import org.apache.servicecomb.service.center.client.model.MicroservicesResponse;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
 
 /**
  * SC注册实现
@@ -57,6 +67,49 @@ public class ScRegister implements Register {
             serviceInstances.add(new ServicecombServiceInstance(microserviceInstance));
         }
         return serviceInstances;
+    }
+
+    @Override
+    public List<String> getServices() {
+        List<String> serviceList = new ArrayList<>();
+        try {
+            MicroservicesResponse microServiceResponse = client.getRawClient().getMicroserviceList();
+            if (microServiceResponse == null || microServiceResponse.getServices() == null) {
+                return serviceList;
+            }
+            for (Microservice microservice : microServiceResponse.getServices()) {
+                final Optional<String> microserviceName = getMicroserviceName(microservice);
+                microserviceName.ifPresent(serviceList::add);
+            }
+        } catch (OperationException ex) {
+            LoggerFactory.getLogger().severe(String.format(Locale.ENGLISH,
+                "Can not query service list from service center! %s", ex.getMessage()));
+        }
+        return serviceList;
+    }
+
+    private Optional<String> getMicroserviceName(Microservice microservice) {
+        final RegisterConfig pluginConfig = PluginConfigManager.getPluginConfig(RegisterConfig.class);
+        if (!environmentEqual(microservice, pluginConfig)) {
+            return Optional.empty();
+        }
+        if (microservice.getAppId().equals(pluginConfig.getApplication())) {
+            return Optional.of(microservice.getServiceName());
+        } else if (pluginConfig.isAllowCrossApp()) {
+            // 当允许跨app时, 则可采用appId.serviceName别名方式返回
+            return Optional.of(String.format(Locale.ENGLISH, "%s.%s", microservice.getAppId(),
+                microservice.getServiceName()));
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    private boolean environmentEqual(Microservice microservice, RegisterConfig pluginConfig) {
+        // empty is equal.
+        if (StringUtils.isBlank(microservice.getEnvironment()) && StringUtils.isBlank(pluginConfig.getEnvironment())) {
+            return true;
+        }
+        return StringUtils.equals(microservice.getEnvironment(), pluginConfig.getEnvironment());
     }
 
     @Override


### PR DESCRIPTION
【issue号/问题单号/需求单号】#533

【修改内容】
1、修复spring注册应用跨app调用场景兼容
2、增加流控默认的重试状态码与重试异常，与线上保持一致
3、流控插件支持读取spring应用配置文件流控规则
4、修改注册插件支持最新SpringCloud版本

【用例描述】暂无用例

【自测情况】本地测试通过

【影响范围】注册插件与流控插件