### PR TITLE
【fix】修复双注册时因从sc查询不到实例导致无法调用的问题

### DIFF
--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-service/src/main/java/com/huawei/registry/service/client/ScClient.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-service/src/main/java/com/huawei/registry/service/client/ScClient.java
@@ -44,6 +44,7 @@ import org.apache.servicecomb.service.center.client.ServiceCenterDiscovery;
 import org.apache.servicecomb.service.center.client.ServiceCenterDiscovery.SubscriptionKey;
 import org.apache.servicecomb.service.center.client.ServiceCenterOperation;
 import org.apache.servicecomb.service.center.client.ServiceCenterRegistration;
+import org.apache.servicecomb.service.center.client.exception.OperationException;
 import org.apache.servicecomb.service.center.client.model.DataCenterInfo;
 import org.apache.servicecomb.service.center.client.model.Framework;
 import org.apache.servicecomb.service.center.client.model.HealthCheck;
@@ -137,11 +138,17 @@ public class ScClient {
      * @return 实例列表
      */
     public List<MicroserviceInstance> queryInstancesByServiceId(String serviceName) {
-        List<MicroserviceInstance> instances;
-        if (registerConfig.isAllowCrossApp()) {
-            instances = queryAllAppInstances(serviceName);
-        } else {
-            instances = getInstanceByCurApp(serviceName);
+        List<MicroserviceInstance> instances = null;
+        try {
+            if (registerConfig.isAllowCrossApp()) {
+                instances = queryAllAppInstances(serviceName);
+            } else {
+                instances = getInstanceByCurApp(serviceName);
+            }
+        } catch (OperationException ex) {
+            LOGGER.severe(String.format(Locale.ENGLISH,
+                "Queried service [%s] instance list from service center failed, reason [%s]", serviceName,
+                ex.getMessage()));
         }
         if (instances == null) {
             return Collections.emptyList();


### PR DESCRIPTION
【issue号/问题单号/需求单号】#541

【修改内容】在双注册后，如果sc注册中心没有对应下游的实例，会直接抛出异常，导致查询实例流程终止，以至于调用中断

【用例描述】暂无用例

【自测情况】本地测试通过

【影响范围】spring双注册

