### PR TITLE
【fix】修复流控与注册插件部分问题

### DIFF
--- a/sermant-agentcore/sermant-agentcore-core/pom.xml
+++ b/sermant-agentcore/sermant-agentcore-core/pom.xml
@@ -353,6 +353,7 @@
             <artifactId>asm-commons</artifactId>
             <version>${asm.version}</version>
         </dependency>
+
     </dependencies>
     <build>
         <extensions>
@@ -425,6 +426,10 @@
                         <relocation>
                             <pattern>io.netty</pattern>
                             <shadedPattern>${shade.common.prefix}.io.netty</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>javax.ws.rs</pattern>
+                            <shadedPattern>${shade.common.prefix}.javax.ws.rs</shadedPattern>
                         </relocation>
                         <relocation>
                             <pattern>javax.inject</pattern>

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/config/SpringEnvironmentInterceptor.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/config/SpringEnvironmentInterceptor.java
@@ -119,8 +119,11 @@ public class SpringEnvironmentInterceptor extends AbstractInterceptor {
      */
     private List<PropertySource<?>> getPropertySources(MutablePropertySources propertySources) {
         final LinkedList<PropertySource<?>> result = new LinkedList<>();
-        propertySources.stream().filter(propertySource -> propertySource instanceof EnumerablePropertySource)
-                .forEach(result::addFirst);
+        for (PropertySource<?> next : propertySources) {
+            if (next instanceof EnumerablePropertySource) {
+                result.addFirst(next);
+            }
+        }
         return result;
     }
 

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/utils/MarkUtils.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/utils/MarkUtils.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.huawei.registry.utils;
+
+/**
+ * 标记工具类 针对线程标记, 后续优化增加多个变量场景
+ *
+ * @author zhouss
+ * @since 2022-05-07
+ */
+public class MarkUtils {
+    private static final ThreadLocal<Boolean> MARK = new ThreadLocal<>();
+
+    private MarkUtils() {
+    }
+
+    /**
+     * 标记
+     */
+    public static void mark() {
+        MARK.set(Boolean.TRUE);
+    }
+
+    /**
+     * 是否标记
+     *
+     * @return 是否标记
+     */
+    public static boolean isMarked() {
+        return MARK.get() != null;
+    }
+
+    /**
+     * 清理标记
+     */
+    public static void unMark() {
+        MARK.remove();
+    }
+}


### PR DESCRIPTION
【issue号/问题单号/需求单号】#542

【修改内容】
1、修复因agentCore引入spi依赖导致宿主加载找不到MessageBodyReader类的问题
2、修复流控插件低版本配置源无Stream问题，改为使用迭代器
3、修复ServerList存在无法获取服务名的问题，对于嵌套调用，限制只对最上层进行拦截合并实例

【用例描述】暂无用例

【自测情况】本地自测通过

【影响范围】流控与注册插件
