### PR TITLE
【fix】优化双注册时实例查询不到时的日志优化

### DIFF
--- a/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/main/java/com/huawei/dynamic/config/interceptors/SpringEnvironmentInterceptor.java
+++ b/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/main/java/com/huawei/dynamic/config/interceptors/SpringEnvironmentInterceptor.java
@@ -54,6 +54,10 @@ public class SpringEnvironmentInterceptor extends DynamicConfigSwitchSupport {
     }
 
     private boolean canSubscribe(ExecuteContext context) {
+        return lowVersionCheck(context) || highVersionCheck(context);
+    }
+
+    private boolean highVersionCheck(ExecuteContext context) {
         final Object primarySources = context.getMemberFieldValue("primarySources");
         if (!(primarySources instanceof Set)) {
             return false;
@@ -65,6 +69,16 @@ public class SpringEnvironmentInterceptor extends DynamicConfigSwitchSupport {
             }
         }
         return true;
+    }
+
+    private boolean lowVersionCheck(ExecuteContext context) {
+        final Object sources = context.getMemberFieldValue("sources");
+        if (!(sources instanceof Set)) {
+            return false;
+        }
+
+        // 仅当source为对应application时, 说明环境变量已完成初始化
+        return ((Set<?>) sources).size() == 1;
     }
 
     private void startSubscribe(ExecuteContext context) {

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/config/SpringEnvironmentInterceptor.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/config/SpringEnvironmentInterceptor.java
@@ -138,6 +138,10 @@ public class SpringEnvironmentInterceptor extends AbstractInterceptor {
     }
 
     private boolean canSubscribe(ExecuteContext context) {
+        return lowVersionCheck(context) || highVersionCheck(context);
+    }
+
+    private boolean highVersionCheck(ExecuteContext context) {
         final Object primarySources = context.getMemberFieldValue("primarySources");
         if (!(primarySources instanceof Set)) {
             return false;
@@ -149,5 +153,15 @@ public class SpringEnvironmentInterceptor extends AbstractInterceptor {
             }
         }
         return true;
+    }
+
+    private boolean lowVersionCheck(ExecuteContext context) {
+        final Object sources = context.getMemberFieldValue("sources");
+        if (!(sources instanceof Set)) {
+            return false;
+        }
+
+        // 仅当source为对应application时, 说明环境变量已完成初始化
+        return ((Set<?>) sources).size() == 1;
     }
 }

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/declarers/health/ZookeeperIndicatorDeclarer.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/declarers/health/ZookeeperIndicatorDeclarer.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2021-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.registry.declarers.health;
+
+import com.huawei.registry.interceptors.health.ZookeeperIndicatorInterceptor;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+
+/**
+ * zookeeper注册中心健康状态检测
+ *
+ * @author zhouss
+ * @since 2021-12-17
+ */
+public class ZookeeperIndicatorDeclarer extends AbstractPluginDeclarer {
+    /**
+     * zookeeper健康检查类
+     */
+    private static final String ENHANCE_CLASS = "org.springframework.cloud.zookeeper.ZookeeperHealthIndicator";
+
+    /**
+     * 拦截类的全限定名
+     */
+    private static final String INTERCEPT_CLASS = ZookeeperIndicatorInterceptor.class.getCanonicalName();
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.nameEquals(ENHANCE_CLASS);
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{
+            InterceptDeclarer.build(MethodMatcher.nameEquals("doHealthCheck"), INTERCEPT_CLASS)
+        };
+    }
+}

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/interceptors/health/ConsulHealthInterceptor.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/interceptors/health/ConsulHealthInterceptor.java
@@ -65,6 +65,12 @@ public class ConsulHealthInterceptor extends SingleStateCloseHandler {
     }
 
     @Override
+    protected ExecuteContext doBefore(ExecuteContext context) {
+        checkState(context, null);
+        return context;
+    }
+
+    @Override
     public ExecuteContext doAfter(ExecuteContext context) {
         final Object result = context.getResult();
         if (result != null) {

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/interceptors/health/EurekaHealthInterceptor.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/interceptors/health/EurekaHealthInterceptor.java
@@ -49,8 +49,7 @@ public class EurekaHealthInterceptor extends SingleStateCloseHandler {
 
     @Override
     public ExecuteContext doBefore(ExecuteContext context) {
-        setArguments(context.getArguments());
-        setTarget(context.getObject());
+        checkState(context, false);
         return context;
     }
 

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/interceptors/health/NacosHealthInterceptor.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/interceptors/health/NacosHealthInterceptor.java
@@ -52,9 +52,8 @@ public class NacosHealthInterceptor extends SingleStateCloseHandler {
     }
 
     @Override
-    public ExecuteContext doBefore(ExecuteContext context) {
-        setArguments(context.getArguments());
-        setTarget(context.getObject());
+    protected ExecuteContext doBefore(ExecuteContext context) {
+        checkState(context, null);
         return context;
     }
 

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/interceptors/health/ZookeeperHealthInterceptor.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/interceptors/health/ZookeeperHealthInterceptor.java
@@ -68,8 +68,7 @@ public class ZookeeperHealthInterceptor extends SingleStateCloseHandler {
 
     @Override
     public ExecuteContext doBefore(ExecuteContext context) {
-        setArguments(context.getArguments());
-        setTarget(context.getObject());
+        checkState(context, null);
         if (arguments.length > 1 && arguments[1] instanceof TreeCacheEvent) {
             TreeCacheEvent event = (TreeCacheEvent) arguments[1];
             if (!isAvailable(event.getType()) && RegisterContext.INSTANCE.compareAndSet(true, false)) {

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/interceptors/health/ZookeeperIndicatorInterceptor.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/interceptors/health/ZookeeperIndicatorInterceptor.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2021-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.registry.interceptors.health;
+
+import com.huawei.registry.support.RegisterSwitchSupport;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+
+/**
+ * 若采用单注册或者已下发关闭原注册中心, 则不需再进行健康检查
+ *
+ * @author zhouss
+ * @since 2022-05-22
+ */
+public class ZookeeperIndicatorInterceptor extends RegisterSwitchSupport {
+    @Override
+    protected ExecuteContext doBefore(ExecuteContext context) {
+        if (needCloseRegisterCenter()) {
+            context.skip(null);
+        }
+        return context;
+    }
+}

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/support/RegisterSwitchSupport.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/support/RegisterSwitchSupport.java
@@ -18,6 +18,7 @@
 package com.huawei.registry.support;
 
 import com.huawei.registry.config.RegisterConfig;
+import com.huawei.registry.config.RegisterDynamicConfig;
 
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.plugin.agent.interceptor.Interceptor;
@@ -46,6 +47,18 @@ public abstract class RegisterSwitchSupport implements Interceptor {
      */
     protected final boolean isEnableSpringRegister() {
         return registerConfig.isEnableSpringRegister();
+    }
+
+    /**
+     * 子类实现，默认为配置的注册开关 若需修改，则需重新实现该方法 满足条件:
+     * <li>已开启spring注册</li>
+     * <li>配置中心已下发关闭注册中心指令或者属于单注册的场景</li>
+     *
+     * @return 是否可关闭注册中心
+     */
+    protected boolean needCloseRegisterCenter() {
+        return (RegisterDynamicConfig.INSTANCE.isNeedCloseOriginRegisterCenter() || !registerConfig.isOpenMigration())
+            && isEnableSpringRegister();
     }
 
     @Override

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
@@ -23,6 +23,7 @@ com.huawei.registry.declarers.ServerListDeclarer
 com.huawei.registry.declarers.health.ConsulWatchConDeclarer
 com.huawei.registry.declarers.health.NacosHealthDeclarer
 com.huawei.registry.declarers.health.ZookeeperHealthDeclarer
+com.huawei.registry.declarers.health.ZookeeperIndicatorDeclarer
 com.huawei.registry.declarers.health.ConsulHealthDeclarer
 com.huawei.registry.declarers.health.EurekaHealthDeclarer
 com.huawei.registry.declarers.cloud3.x.ZookeeperInstanceSupplierDeclarer

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-service/src/main/java/com/huawei/registry/service/client/ScClient.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-service/src/main/java/com/huawei/registry/service/client/ScClient.java
@@ -21,6 +21,7 @@ package com.huawei.registry.service.client;
 import com.huawei.registry.config.ConfigConstants;
 import com.huawei.registry.config.RegisterConfig;
 import com.huawei.registry.context.RegisterContext;
+import com.huawei.registry.service.client.ScDiscovery.SubscriptionKey;
 import com.huawei.registry.utils.HostUtils;
 
 import com.huaweicloud.sermant.core.common.LoggerFactory;
@@ -40,8 +41,6 @@ import org.apache.servicecomb.service.center.client.AddressManager;
 import org.apache.servicecomb.service.center.client.RegistrationEvents.HeartBeatEvent;
 import org.apache.servicecomb.service.center.client.RegistrationEvents.MicroserviceRegistrationEvent;
 import org.apache.servicecomb.service.center.client.ServiceCenterClient;
-import org.apache.servicecomb.service.center.client.ServiceCenterDiscovery;
-import org.apache.servicecomb.service.center.client.ServiceCenterDiscovery.SubscriptionKey;
 import org.apache.servicecomb.service.center.client.ServiceCenterOperation;
 import org.apache.servicecomb.service.center.client.ServiceCenterRegistration;
 import org.apache.servicecomb.service.center.client.exception.OperationException;
@@ -113,7 +112,7 @@ public class ScClient {
 
     private MicroserviceInstance microserviceInstance;
 
-    private ServiceCenterDiscovery serviceCenterDiscovery;
+    private ScDiscovery serviceCenterDiscovery;
 
     /**
      * 初始化
@@ -274,7 +273,7 @@ public class ScClient {
     public void onMicroserviceRegistrationEvent(MicroserviceRegistrationEvent event) {
         if (event.isSuccess()) {
             if (serviceCenterDiscovery == null) {
-                serviceCenterDiscovery = new ServiceCenterDiscovery(serviceCenterClient, EVENT_BUS);
+                serviceCenterDiscovery = new ScDiscovery(serviceCenterClient, EVENT_BUS);
                 serviceCenterDiscovery.updateMyselfServiceId(microservice.getServiceId());
                 serviceCenterDiscovery.setPollInterval(registerConfig.getPullInterval());
                 serviceCenterDiscovery.startDiscovery();

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-service/src/main/java/com/huawei/registry/service/client/ScDiscovery.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-service/src/main/java/com/huawei/registry/service/client/ScDiscovery.java
@@ -1,0 +1,322 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Based org/apache/servicecomb/service/center/client/ServiceCenterDiscovery.java
+ * from the Apache ServiceComb Java Chassis project.
+ */
+
+package com.huawei.registry.service.client;
+
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
+
+import org.apache.servicecomb.http.client.task.AbstractTask;
+import org.apache.servicecomb.http.client.task.Task;
+import org.apache.servicecomb.service.center.client.DiscoveryEvents.InstanceChangedEvent;
+import org.apache.servicecomb.service.center.client.DiscoveryEvents.PullInstanceEvent;
+import org.apache.servicecomb.service.center.client.ServiceCenterClient;
+import org.apache.servicecomb.service.center.client.ServiceCenterDiscovery;
+import org.apache.servicecomb.service.center.client.exception.OperationException;
+import org.apache.servicecomb.service.center.client.model.FindMicroserviceInstancesResponse;
+import org.apache.servicecomb.service.center.client.model.Microservice;
+import org.apache.servicecomb.service.center.client.model.MicroserviceInstance;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * service center实例发现, 原{@link ServiceCenterDiscovery}日志处理存在问题，因此此处重新实现
+ *
+ * @author zhouss
+ * @since 2022-05-11
+ */
+public class ScDiscovery extends AbstractTask {
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
+    /**
+     * 默认拉取间隔
+     */
+    private static final long DEFAULT_POLL_INTERVAL = 15000L;
+
+    /**
+     * endpoint最大长度，超过该长度直接截取
+     */
+    private static final int MAX_LEN_OF_ENDPOINT = 64;
+
+    /**
+     * 查询所有的版本号
+     */
+    private static final String ALL_VERSION = "0+";
+
+    private final Object lock = new Object();
+
+    private final ServiceCenterClient serviceCenterClient;
+
+    private final EventBus eventBus;
+
+    private final Map<SubscriptionKey, SubscriptionValue> instancesCache = new ConcurrentHashMap<>();
+
+    private final Map<String, Microservice> microserviceCache = new ConcurrentHashMap<>();
+
+    private final List<SubscriptionKey> failedInstances = new ArrayList<>();
+
+    private String myselfServiceId;
+
+    private long pollInterval;
+
+    private boolean started = false;
+
+    /**
+     * 构造器
+     *
+     * @param serviceCenterClient sc客户端
+     * @param eventBus            事件总栈
+     */
+    public ScDiscovery(ServiceCenterClient serviceCenterClient, EventBus eventBus) {
+        super("service-center-discovery-task");
+        this.serviceCenterClient = serviceCenterClient;
+        this.eventBus = eventBus;
+        this.eventBus.register(this);
+        this.pollInterval = DEFAULT_POLL_INTERVAL;
+    }
+
+    /**
+     * 设置拉取间隔
+     *
+     * @param interval 拉取间隔， 单位ms
+     */
+    public void setPollInterval(long interval) {
+        if (interval > ServiceCenterDiscovery.MAX_INTERVAL || interval < ServiceCenterDiscovery.MIN_INTERVAL) {
+            return;
+        }
+        this.pollInterval = interval;
+    }
+
+    /**
+     * 更新自身服务ID
+     *
+     * @param curServiceId 自身服务编号
+     */
+    public void updateMyselfServiceId(String curServiceId) {
+        this.myselfServiceId = curServiceId;
+    }
+
+    /**
+     * 开启相关定时任务，拉取实例数据
+     */
+    public void startDiscovery() {
+        if (!started) {
+            started = true;
+            startTask(new PullInstanceTask());
+        }
+    }
+
+    /**
+     * 注册订阅者
+     *
+     * @param subscriptionKey 订阅者
+     */
+    public void registerIfNotPresent(SubscriptionKey subscriptionKey) {
+        if (this.instancesCache.get(subscriptionKey) == null) {
+            synchronized (lock) {
+                if (this.instancesCache.get(subscriptionKey) == null) {
+                    SubscriptionValue value = new SubscriptionValue();
+                    pullInstance(subscriptionKey, value, Level.INFO);
+                    this.instancesCache.put(subscriptionKey, value);
+                }
+            }
+        }
+    }
+
+    /**
+     * 获取实例缓存
+     *
+     * @param key 订阅者
+     * @return 实例数据
+     */
+    public List<MicroserviceInstance> getInstanceCache(SubscriptionKey key) {
+        return this.instancesCache.get(key).instancesCache;
+    }
+
+    /**
+     * 订阅拉取事件
+     *
+     * @param event 拉取事件
+     */
+    @Subscribe
+    public void onPullInstanceEvent(PullInstanceEvent event) {
+        pullAllInstance();
+    }
+
+    private void pullInstance(SubscriptionKey key, SubscriptionValue value, Level level) {
+        if (myselfServiceId == null) {
+            // registration not ready
+            return;
+        }
+        try {
+            FindMicroserviceInstancesResponse instancesResponse = serviceCenterClient
+                .findMicroserviceInstance(myselfServiceId, key.appId, key.serviceName, ALL_VERSION, value.revision);
+            if (instancesResponse.isModified()) {
+                List<MicroserviceInstance> instances =
+                    instancesResponse.getMicroserviceInstancesResponse().getInstances()
+                        == null ? Collections.emptyList()
+                        : instancesResponse.getMicroserviceInstancesResponse().getInstances();
+                setMicroserviceInfo(instances);
+                LOGGER.info(String.format(Locale.ENGLISH,
+                    "Instance changed event, current: revision={%s}, instances={%s}; "
+                        + "origin: revision={%s}, instances={%s}; appId={%s}, serviceName={%s}",
+                    instancesResponse.getRevision(),
+                    instanceToString(instances),
+                    value.revision,
+                    instanceToString(value.instancesCache),
+                    key.appId,
+                    key.serviceName
+                ));
+                value.instancesCache = instances;
+                value.revision = instancesResponse.getRevision();
+                eventBus.post(new InstanceChangedEvent(key.appId, key.serviceName,
+                    value.instancesCache));
+            }
+        } catch (OperationException ex) {
+            String message = String.format(Locale.ENGLISH,
+                "find service {%s}#{%s} instance failed. caused by %s, if you are run with mode migration, please "
+                    + "ignore it!", key.appId, key.serviceName,
+                ex.getMessage());
+            LOGGER.log(level, message);
+            LOGGER.log(Level.FINE, message, ex);
+            failedInstances.add(key);
+        }
+    }
+
+    private void setMicroserviceInfo(List<MicroserviceInstance> instances) {
+        instances.forEach(instance -> {
+            Microservice microservice = microserviceCache
+                .computeIfAbsent(instance.getServiceId(), id -> {
+                    try {
+                        return serviceCenterClient.getMicroserviceByServiceId(id);
+                    } catch (OperationException ex) {
+                        LOGGER.log(Level.INFO, String.format(Locale.ENGLISH,
+                            "Find microservice by id={%s} failed", id), ex);
+                        throw ex;
+                    }
+                });
+            instance.setMicroservice(microservice);
+        });
+    }
+
+    private synchronized void pullAllInstance() {
+        instancesCache.forEach((key, value) -> this.pullInstance(key, value, Level.FINE));
+        if (failedInstances.isEmpty()) {
+            return;
+        }
+        failedInstances.forEach(instancesCache::remove);
+        failedInstances.clear();
+    }
+
+    private static String instanceToString(List<MicroserviceInstance> instances) {
+        if (instances == null) {
+            return "";
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (MicroserviceInstance instance : instances) {
+            for (String endpoint : instance.getEndpoints()) {
+                sb.append(endpoint.length() > MAX_LEN_OF_ENDPOINT
+                    ? endpoint.substring(0, MAX_LEN_OF_ENDPOINT) : endpoint);
+                sb.append("|");
+            }
+            sb.append(instance.getServiceName());
+            sb.append("|");
+        }
+        sb.append("#");
+        return sb.toString();
+    }
+
+    /**
+     * 定时拉取任务
+     *
+     * @since 2022-05-11
+     */
+    class PullInstanceTask implements Task {
+        @Override
+        public void execute() {
+            pullAllInstance();
+
+            startTask(new BackOffSleepTask(pollInterval, new PullInstanceTask()));
+        }
+    }
+
+    /**
+     * 订阅实例
+     *
+     * @since 2022-05-11
+     */
+    public static class SubscriptionValue {
+        String revision;
+
+        List<MicroserviceInstance> instancesCache;
+    }
+
+    /**
+     * 订阅者
+     *
+     * @since 2022-05-11
+     */
+    public static class SubscriptionKey {
+        final String appId;
+
+        final String serviceName;
+
+        /**
+         * 订阅者
+         *
+         * @param appId       appName
+         * @param serviceName 服务名
+         */
+        public SubscriptionKey(String appId, String serviceName) {
+            this.appId = appId;
+            this.serviceName = serviceName;
+        }
+
+        @Override
+        public boolean equals(Object target) {
+            if (this == target) {
+                return true;
+            }
+            if (target == null || getClass() != target.getClass()) {
+                return false;
+            }
+            SubscriptionKey that = (SubscriptionKey) target;
+            return appId.equals(that.appId) && serviceName.equals(that.serviceName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(appId, serviceName);
+        }
+    }
+}


### PR DESCRIPTION
【issue号/问题单号/需求单号】#546

【修改内容】
1、优化双注册因cse无下游实例而不断输出错误日志问题，第一次使用info级日志提示，后续定时器则将日志级别定为优先级更低的fine
2、修复流控与动态配置插件1.x版本springboot无法获取服务名的问题
3、原注册中心关闭逻辑优化，当采用单注册时，默认第一次心跳即关闭原注册中心客户端心跳

【用例描述】暂无用例

【自测情况】本地测试通过

【影响范围】注册插件
