### PR TITLE
【fix】兼容在alibaba dubbo在2.6.6-2.6.12版本区间其invocation的invoker为空的场景

### DIFF
--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/ApacheDubboInterceptor.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/ApacheDubboInterceptor.java
@@ -115,7 +115,7 @@ public class ApacheDubboInterceptor extends InterceptorSupporter {
     }
 
     @Override
-    protected boolean canInvoke() {
+    protected boolean canInvoke(ExecuteContext context) {
         return true;
     }
 }

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/retry/ApacheDubboInvokerInterceptor.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/retry/ApacheDubboInvokerInterceptor.java
@@ -61,6 +61,12 @@ public class ApacheDubboInvokerInterceptor extends InterceptorSupporter {
     private final Retry retry = new ApacheDubboRetry();
 
     /**
+     * 黑名单，该名单内的类不拦截
+     */
+    private final List<String> backList = Collections
+        .singletonList("org.apache.dubbo.rpc.cluster.support.registry.ZoneAwareClusterInvoker");
+
+    /**
      * 转换apache dubbo 注意，该方法不可抽出，由于宿主依赖仅可由该拦截器加载，因此抽出会导致找不到类
      *
      * @param invocation 调用信息
@@ -170,6 +176,11 @@ public class ApacheDubboInvokerInterceptor extends InterceptorSupporter {
             }
             return placeHolderMethod;
         });
+    }
+
+    @Override
+    protected boolean canInvoke(ExecuteContext context) {
+        return super.canInvoke(context) && backList.contains(context.getObject().getClass().getName());
     }
 
     @Override

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/service/InterceptorSupporter.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/service/InterceptorSupporter.java
@@ -194,7 +194,7 @@ public abstract class InterceptorSupporter extends ReflectMethodCacheSupport imp
 
     @Override
     public ExecuteContext before(ExecuteContext context) throws Exception {
-        if (canInvoke()) {
+        if (canInvoke(context)) {
             return doBefore(context);
         }
         return context;
@@ -202,7 +202,7 @@ public abstract class InterceptorSupporter extends ReflectMethodCacheSupport imp
 
     @Override
     public ExecuteContext after(ExecuteContext context) throws Exception {
-        if (canInvoke()) {
+        if (canInvoke(context)) {
             return doAfter(context);
         }
         return context;
@@ -210,7 +210,7 @@ public abstract class InterceptorSupporter extends ReflectMethodCacheSupport imp
 
     @Override
     public ExecuteContext onThrow(ExecuteContext context) throws Exception {
-        if (canInvoke()) {
+        if (canInvoke(context)) {
             return doThrow(context);
         }
         return context;
@@ -259,9 +259,10 @@ public abstract class InterceptorSupporter extends ReflectMethodCacheSupport imp
     /**
      * 是否可调用内部方法逻辑
      *
+     * @param context 上下文
      * @return 是否可调用
      */
-    protected boolean canInvoke() {
+    protected boolean canInvoke(ExecuteContext context) {
         return !RetryContext.INSTANCE.isMarkedRetry();
     }
 }


### PR DESCRIPTION
【issue号/问题单号/需求单号】#548

【修改内容】流控插件兼容alibaba dubbo在调用时下游invoker的场景

【用例描述】暂无用例

【自测情况】本地自测通过

【影响范围】流控插件
