### PR TITLE
【feature】插件加载增加场景参数配置，支持通过-D指定场景名

### DIFF
--- a/sermant-agentcore/sermant-agentcore-config/config/all/plugins.yaml
+++ b/sermant-agentcore/sermant-agentcore-config/config/all/plugins.yaml
@@ -9,3 +9,13 @@ plugins:
   - loadbalancer
 adaptors:
   - lubanops
+profiles:
+  cse:
+    - flowcontrol
+    - service-router
+    - service-registry
+    - dynamic-config
+  apm:
+    - flowcontrol
+    - service-router
+profile: cse,apm

--- a/sermant-agentcore/sermant-agentcore-config/config/plugins.yaml
+++ b/sermant-agentcore/sermant-agentcore-config/config/plugins.yaml
@@ -9,3 +9,13 @@ plugins:
   - dynamic-config
 adaptors:
   - lubanops
+profiles:
+  cse:
+    - flowcontrol
+    - service-router
+    - service-registry
+    - dynamic-config
+  apm:
+    - flowcontrol
+    - service-router
+profile: cse,apm

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/common/CommonConstant.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/common/CommonConstant.java
@@ -97,6 +97,10 @@ public class CommonConstant {
      */
     public static final String LOG_SETTING_FILE_KEY = "log.setting.file";
 
+    /**
+     * 插件加载场景键
+     */
+    public static final String PLUGIN_PROFILE = "profile";
     private CommonConstant() {
     }
 }

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/config/utils/ConfigValueUtil.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/config/utils/ConfigValueUtil.java
@@ -330,9 +330,9 @@ public class ConfigValueUtil {
      * 通过环境变量或者系统变量获取 环境变量 > 系统变量
      *
      * @param key 配置键
-     * @return 变脸值
+     * @return 变量值
      */
-    private static String getValFromEnv(String key) {
+    public static String getValFromEnv(String key) {
         final String envVal = System.getenv(key);
         if (envVal != null) {
             return envVal;

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/config/PluginSetting.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/config/PluginSetting.java
@@ -17,6 +17,7 @@
 package com.huaweicloud.sermant.core.plugin.config;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * 插件设定配置
@@ -36,6 +37,16 @@ public class PluginSetting {
      */
     private List<String> adaptors;
 
+    /**
+     * 场景与插件映射关系
+     */
+    private Map<String, List<String>> profiles;
+
+    /**
+     * 启动场景名
+     */
+    private String profile;
+
     public List<String> getPlugins() {
         return plugins;
     }
@@ -50,5 +61,21 @@ public class PluginSetting {
 
     public void setAdaptors(List<String> adaptors) {
         this.adaptors = adaptors;
+    }
+
+    public void setProfiles(Map<String, List<String>> profiles) {
+        this.profiles = profiles;
+    }
+
+    public Map<String, List<String>> getProfiles() {
+        return profiles;
+    }
+
+    public String getProfile() {
+        return profile;
+    }
+
+    public void setProfile(String profile) {
+        this.profile = profile;
     }
 }


### PR DESCRIPTION
【issue号/问题单号/需求单号】#597

【修改内容】

1. 插件配置文增加场景与插件的映射配置(目前有cse场景)；
2. 插件配置文件增加场景参数(默认cse场景)；
3. 插件加载场景值支持启动命令-Dprofile=***指定；
4. 场景参数与插件参数不冲突，配置文件中场景参数与命令行场景参数不冲突，三者存在的话取插件交集进行加载。

【用例描述】不需测试用例

【自测情况】本地静态检查通过。

【影响范围】

1. 用户可以根据自己的需要选择使用场景，在配置文件中或者命令行指定场景；
2. 无使用场景的用户，不需进行修改。