### PR TITLE
【fix】修复监听KIE配置时，无法监听env为空的配置

### DIFF
--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/service/dynamicconfig/utils/LabelGroupUtils.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/service/dynamicconfig/utils/LabelGroupUtils.java
@@ -141,10 +141,14 @@ public class LabelGroupUtils {
             final String[] labels = decode.split("&");
             for (String label : labels) {
                 final String[] labelKv = label.split("=");
-                if (labelKv.length != KV_LEN) {
-                    continue;
+                if (labelKv.length == KV_LEN) {
+                    result.put(labelKv[0], labelKv[1]);
+                } else if (labelKv.length == 1) {
+                    // 仅配置了KEY的情况, 使用空串代替
+                    result.put(labelKv[0], "");
+                } else {
+                    LOGGER.warning(String.format(Locale.ENGLISH, "Invalid label [%s]", label));
                 }
-                result.put(labelKv[0], labelKv[1]);
             }
         } catch (UnsupportedEncodingException ignored) {
             // ignored


### PR DESCRIPTION
【issue号/问题单号/需求单号】 #604 

【修改内容】修复监听KIE配置时，无法监听env为空的配置

【用例描述】暂无

【自测情况】本地自测通过

【影响范围】动态配置