### PR TITLE
 [Bug] fix HideUtilityClassConstructor check to skip main method and SpringBootApplication annotation check

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -423,6 +423,11 @@
             <property name="packageAllowed" value="true"/>
             <property name="protectedAllowed" value="true"/>
         </module>
+        <!--SuppressionXpathFilter：跳过main方法&SpringBootApplication注释检查-->
+        <module name="SuppressionXpathFilter">
+            <property name="file" value="suppressions.xml"/>
+            <property name="optional" value="false"/>
+        </module>
         <!-- 检查类成员对外可见性，只有Static final的可以是public对外访问-->
         <module name="HideUtilityClassConstructor"/>
         <!-- Utility类(只有静态成员和方法的类)不能有公有构造函数 -->

--- a/suppressions.xml
+++ b/suppressions.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!DOCTYPE suppressions PUBLIC
+        "-//Checkstyle//DTD SuppressionXpathFilter Experimental Configuration 1.2//EN"
+        "https://checkstyle.org/dtds/suppressions_1_2_xpath_experimental.dtd">
+
+<suppressions>
+    <!--  Suppress for any classes that contain method named "main"  -->
+    <suppress-xpath checks="HideUtilityClassConstructor"
+                    query="//CLASS_DEF[//METHOD_DEF[./IDENT[@text='main']]]"/>
+
+    <!--  Suppress for any classes that are annotated with "SpringBootApplication"  -->
+    <suppress-xpath checks="HideUtilityClassConstructor"
+                    query="//CLASS_DEF[//MODIFIERS/ANNOTATION[./IDENT[@text='SpringBootApplication']]]"/>
+
+</suppressions>


### PR DESCRIPTION
What type of PR is this?

/checkstyle 

**Utility classes should not have a public or default constructor**

Which issue(s) this PR fixes: #627 

Fixes： 
1.  Suppress for any classes that contain method named "main"
2. Suppress for any classes that are annotated with "SpringBootApplication"

Use case description: No

Does this PR introduce a user-facing change?

No

Additional documentation e.g., usage docs, etc.:

No
