### PR TITLE
【bug】修复加载某个插件过程发生异常导致整个agent启动失败的问题

### DIFF
--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/PluginManager.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/PluginManager.java
@@ -37,6 +37,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.jar.JarFile;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -71,7 +72,12 @@ public class PluginManager {
             return false;
         }
         for (String pluginName : pluginNames) {
-            initPlugin(pluginName, pluginPackage, instrumentation);
+            try {
+                initPlugin(pluginName, pluginPackage, instrumentation);
+            } catch (Exception ex) {
+                LOGGER.log(Level.SEVERE, String.format(Locale.ENGLISH,
+                        "load plugin failed, plugin name: %s", pluginName), ex);
+            }
         }
         return true;
     }

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/adaptor/AdaptorManager.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/adaptor/AdaptorManager.java
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.jar.JarFile;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -83,11 +84,16 @@ public class AdaptorManager {
         try {
             pluginPackage = BootArgsIndexer.getPluginPackageDir().getCanonicalPath();
         } catch (IOException ignored) {
-            LOGGER.warning("Resolve plugin package failed. ");
+            LOGGER.warning("Resolve adaptor package failed. ");
             return false;
         }
         for (String adaptorName : adaptorNames) {
-            initAdaptor(adaptorName, pluginPackage, config, instrumentation);
+            try {
+                initAdaptor(adaptorName, pluginPackage, config, instrumentation);
+            } catch (Exception ex) {
+                LOGGER.log(Level.SEVERE, String.format(Locale.ENGLISH,
+                        "load adaptor failed, adaptor name: %s", adaptorName), ex);
+            }
         }
         addStopHook();
         return true;


### PR DESCRIPTION
【issue号/问题单号/需求单号】#638

【修改内容】捕获启动时插件加载过程中的异常，使其不影响其他插件的加载和agent的运行

【用例描述】暂无用例

【自测情况】
1. 测试条件：sermant-agent加载两个以上插件，对其中一个插件构造异常。
2. 测试步骤：启动宿主应用挂载sermant-agent。
3. 预期结果：异常插件不影响其他插件的加载，agent正常运行

【影响范围】解决用户加载多个插件可能出现的加载失败问题