### PR TITLE
【bug】修复删除命名空间后证书失效的问题

### DIFF
--- a/sermant-injector/scripts/certificate_k8s_1.19+/certificate.sh
+++ b/sermant-injector/scripts/certificate_k8s_1.19+/certificate.sh
@@ -15,8 +15,8 @@ distinguished_name = dn
 
 [ dn ]
 C = CN
-+CN = system:node:sermant-injector-node
-+O = system:nodes
+CN = system:node:sermant-injector-node
+O = system:nodes
 
 [ req_ext ]
 subjectAltName = @alt_names
@@ -42,7 +42,9 @@ openssl req -new -key ${APP}.key -out ${APP}.csr -config ${APP}.conf
 
 kubectl create ns ${NAMESPACE}
 
-kubectl create -f - <<EOF
+kubectl delete csr ${APP}.${NAMESPACE}.svc
+
+kubectl apply -f - <<EOF
 apiVersion: certificates.k8s.io/v1
 kind: CertificateSigningRequest
 metadata:
@@ -59,7 +61,7 @@ EOF
 
 kubectl certificate approve ${APP}.${NAMESPACE}.svc
 
-kubectl create -f - <<EOF
+kubectl apply -f - <<EOF
 apiVersion: v1
 kind: Secret
 metadata:

--- a/sermant-injector/scripts/certificate_k8s_1.21-/certificate.sh
+++ b/sermant-injector/scripts/certificate_k8s_1.21-/certificate.sh
@@ -40,7 +40,9 @@ openssl req -new -key ${APP}.key -out ${APP}.csr -config ${APP}.conf
 
 kubectl create ns ${NAMESPACE}
 
-kubectl create -f - <<EOF
+kubectl delete csr ${APP}.${NAMESPACE}.svc
+
+kubectl apply -f - <<EOF
 apiVersion: certificates.k8s.io/v1beta1
 kind: CertificateSigningRequest
 metadata:
@@ -56,7 +58,7 @@ EOF
 
 kubectl certificate approve ${APP}.${NAMESPACE}.svc
 
-kubectl create -f - <<EOF
+kubectl apply -f - <<EOF
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
【issue号/问题单号/需求单号】#624

【修改内容】修复删除命名空间后证书失效的问题

【用例描述】暂无用例

【自测情况】删除sermant-injector的命名空间后重新执行脚本证书可用

【影响范围】不影响框架本身以及插件