### PR TITLE
【BUG】backend模块指定repackage版本

### DIFF
--- a/sermant-backend/pom.xml
+++ b/sermant-backend/pom.xml
@@ -216,6 +216,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.boot.version}</version>
                 <configuration>
                     <mainClass>com.huawei.sermant.backend.NettyServerApplication</mainClass>
                     <outputDirectory>${package.output.dir}</outputDirectory>


### PR DESCRIPTION
【issue号/问题单号/需求单号】#642

【修改内容】

backend模块pom文件中指定repackage的版本。

【用例描述】不需测试用例

【自测情况】

本地检查通过：
检查方式：(1) 执行 mvn package -P backend. (2) 命令执行成功，在项目根目录出现backend模块 jar包。
 
【影响范围】对用户的使用有没有影响