### PR TITLE
【feature】支持插件自身决定是否要进行拦截点增强

### DIFF
--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/agent/collector/PluginCollectorManager.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/agent/collector/PluginCollectorManager.java
@@ -87,7 +87,9 @@ public class PluginCollectorManager {
         final List<PluginDeclarer> declares = new ArrayList<>();
         for (PluginCollector collector : COLLECTORS) {
             for (PluginDeclarer declarer : collector.getDeclarers()) {
-                declares.add(declarer);
+                if (declarer.isEnabled()) {
+                    declares.add(declarer);
+                }
             }
         }
         return declares;

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/agent/declarer/PluginDeclarer.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/agent/declarer/PluginDeclarer.java
@@ -50,4 +50,13 @@ public interface PluginDeclarer {
      * @return 超类声明集
      */
     SuperTypeDeclarer[] getSuperTypeDeclarers();
+
+    /**
+     * 由插件声明器决定是否需要增强被拦截的方法，默认为true
+     *
+     * @return 加载与否
+     */
+    default boolean isEnabled() {
+        return true;
+    }
 }

--- a/sermant-example/demo-application/src/main/java/com/huawei/example/demo/DemoApplication.java
+++ b/sermant-example/demo-application/src/main/java/com/huawei/example/demo/DemoApplication.java
@@ -17,6 +17,7 @@
 package com.huawei.example.demo;
 
 import com.huawei.example.demo.service.DemoAnnotationService;
+import com.huawei.example.demo.service.DemoCheckEnableService;
 import com.huawei.example.demo.service.DemoNameService;
 import com.huawei.example.demo.service.DemoSuperTypeService;
 import com.huawei.example.demo.service.DemoTraceService;
@@ -48,6 +49,7 @@ public class DemoApplication {
         classSuffixAndParamsTest();
         pluginServiceAndConfigTest();
         tracingFuncTest();
+        checkDeclarerEnableTest();
     }
 
     /**
@@ -135,5 +137,13 @@ public class DemoApplication {
     private static void tracingFuncTest() {
         LOGGER.info("tracingFuncTest");
         DemoTraceService.trace();
+    }
+
+    /**
+     * PluginDeclarer#isEnable()方法测试
+     */
+    private static void checkDeclarerEnableTest() {
+        LOGGER.info("checkDeclarerEnableTest");
+        DemoCheckEnableService.exampleFunc();
     }
 }

--- a/sermant-example/demo-application/src/main/java/com/huawei/example/demo/service/DemoCheckEnableService.java
+++ b/sermant-example/demo-application/src/main/java/com/huawei/example/demo/service/DemoCheckEnableService.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.example.demo.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * 用于测试插件内部增强开关是否生效的被拦截点
+ *
+ * @author lilai
+ * @version 1.0.0
+ * @since 2022-08-13
+ */
+public class DemoCheckEnableService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DemoCheckEnableService.class);
+
+    /**
+     * 被拦截的构造函数
+     */
+    private DemoCheckEnableService() {
+        LOGGER.info("DemoCheckEnableService: constructor");
+    }
+
+    /**
+     * 被拦截的示例方法
+     */
+    public static void exampleFunc() {
+        LOGGER.info("DemoCheckEnableService: exampleFunc");
+    }
+}

--- a/sermant-example/demo-plugin/src/main/java/com/huawei/example/demo/declarer/DemoCheckEnableDeclarer.java
+++ b/sermant-example/demo-plugin/src/main/java/com/huawei/example/demo/declarer/DemoCheckEnableDeclarer.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.example.demo.declarer;
+
+import com.huawei.example.demo.interceptor.DemoCheckEnableInterceptor;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+
+/**
+ * 测试插件自身按实际情况决定是否要增强声明的拦截点
+ *
+ * @author lilai
+ * @version 1.0.0
+ * @since 2022-08-13
+ */
+public class DemoCheckEnableDeclarer extends AbstractPluginDeclarer {
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.nameEquals("com.huawei.example.demo.service.DemoCheckEnableService");
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{
+                InterceptDeclarer.build(MethodMatcher.nameEquals("exampleFunc"), new DemoCheckEnableInterceptor())
+        };
+    }
+
+    /**
+     * 测试插件自身按实际情况决定是否要增强声明的拦截点
+     *
+     * @return 是否需要增强
+     */
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
+}

--- a/sermant-example/demo-plugin/src/main/java/com/huawei/example/demo/interceptor/DemoCheckEnableInterceptor.java
+++ b/sermant-example/demo-plugin/src/main/java/com/huawei/example/demo/interceptor/DemoCheckEnableInterceptor.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.example.demo.interceptor;
+
+import com.huawei.example.demo.common.DemoLogger;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
+
+import java.util.Locale;
+
+/**
+ * 用于测试插件内部增强开关是否生效
+ *
+ * @author lilai
+ * @version 1.0.0
+ * @since 2022-08-13
+ */
+public class DemoCheckEnableInterceptor extends AbstractInterceptor {
+    @Override
+    public ExecuteContext before(ExecuteContext context) throws Exception {
+        DemoLogger.println(String.format(Locale.ROOT, "[DemoCheckEnableInterceptor]before, class: %s, method: %s.",
+                context.getRawCls().getName(), context.getMethod().getName()));
+        return context;
+    }
+
+    @Override
+    public ExecuteContext after(ExecuteContext context) throws Exception {
+        DemoLogger.println(String.format(Locale.ROOT, "[DemoCheckEnableInterceptor]after, class: %s, method: %s.",
+                context.getRawCls().getName(), context.getMethod().getName()));
+        return context;
+    }
+}

--- a/sermant-example/demo-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
+++ b/sermant-example/demo-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
@@ -6,3 +6,4 @@ com.huawei.example.demo.declarer.DemoBootstrapDeclarer
 com.huawei.example.demo.declarer.DemoNameInfixDeclarer
 com.huawei.example.demo.declarer.DemoNamePrefixDeclarer
 com.huawei.example.demo.declarer.DemoNameSuffixDeclarer
+com.huawei.example.demo.declarer.DemoCheckEnableDeclarer


### PR DESCRIPTION
【issue号/问题单号/需求单号】#646

【修改内容】

1. PluginDeclarer增加isEnable()方法，插件可以实现该方法用于控制自身定义的PluginDeclarer是否需要被框架进行字节码增强。默认值为true
2. 增加demo方法用于验证上述开关是否生效

【用例描述】暂无用例

【自测情况】1. 测试过程：demo-application挂载demo-plugin进行测试；比较DemoCheckEnableDeclarer#isEnable()分别和true和false时，拦截点是否被增强。 2. 测试结果：true拦截点生效，false拦截点失效

【影响范围】插件开发过程中可以按自身场景来实现PluginDeclarer#isEnable()方法，可以减少某些场景无需增强的拦截点以提高框架的整体性能。