### PR TITLE
【feature】优化.properties配置文件Map/List/Set数据格式配置

### DIFF
--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/common/CommonConstant.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/common/CommonConstant.java
@@ -101,6 +101,22 @@ public class CommonConstant {
      * 插件加载场景键
      */
     public static final String PLUGIN_PROFILE = "profile";
+
+    /**
+     * 逗号
+     */
+    public static final String COMMA = ",";
+
+    /**
+     * 点号
+     */
+    public static final String DOT = ".";
+
+    /**
+     * 冒号
+     */
+    public static final String COLON = ":";
+
     private CommonConstant() {
     }
 }


### PR DESCRIPTION
【issue号/问题单号/需求单号】#649

【修改内容】支持类spring方式配置.properties配置文件中的Map/List/Set

(1)支持如下方式配置Map
xxx.mapName.key1=value1
xxx.mapName.key2=value2
或
xxx.mapName=key1:value1,key2:value2
(2)支持如下方式配置List或者Set
xxx.xxx.listName[0]=elem1
xxx.xxx.listName[1]=elem2
或
xxx.xxx.listName=elem1,elem2

【用例描述】暂无用例

【自测情况】1. 测试场景：config.properties 按两种方式配置Map/List/Set；启动sermant-agent测试是否正确获取数据。2. 测试结果：各种方式sermant-agent均能正确获取配置文件。

【影响范围】.properties文件支持新的Map/List/Set配置方式
