### PR TITLE
【feature】适配declarer的开关，优化双注册去重逻辑

### DIFF
--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/config/RegistrationProperties.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/config/RegistrationProperties.java
@@ -24,6 +24,8 @@ import com.huaweicloud.sermant.core.plugin.service.PluginServiceManager;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.commons.util.InetUtils;
+import org.springframework.cloud.commons.util.InetUtils.HostInfo;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.env.Environment;
@@ -49,6 +51,9 @@ public class RegistrationProperties {
     @Autowired
     private Environment environment;
 
+    @Autowired
+    private InetUtils inetUtils;
+
     /**
      * 初始化
      */
@@ -58,8 +63,9 @@ public class RegistrationProperties {
         RegisterContext.INSTANCE.getClientInfo().setServiceId(serviceName);
         RegisterContext.INSTANCE.getClientInfo().setPort(port);
         RegisterContext.INSTANCE.getClientInfo().setMeta(new HashMap<>());
-        RegisterContext.INSTANCE.getClientInfo().setHost(HostUtils.getHostName());
-        RegisterContext.INSTANCE.getClientInfo().setIp(HostUtils.getMachineIp());
+        final HostInfo hostInfo = inetUtils.findFirstNonLoopbackHostInfo();
+        RegisterContext.INSTANCE.getClientInfo().setHost(hostInfo.getHostname());
+        RegisterContext.INSTANCE.getClientInfo().setIp(hostInfo.getIpAddress());
         RegisterContext.INSTANCE.getClientInfo().setZone(
                 environment.getProperty(SpringRegistryConstants.SPRING_LOAD_BALANCER_ZONE));
 

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/declarers/AbstractBaseConfigDeclarer.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/declarers/AbstractBaseConfigDeclarer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.huawei.registry.declarers;
+
+import com.huawei.registry.config.RegisterConfig;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
+
+/**
+ * 拦截点基础配置
+ *
+ * @author zhouss
+ * @since 2022-08-18
+ */
+public abstract class AbstractBaseConfigDeclarer extends AbstractPluginDeclarer {
+    /**
+     * 注册配置
+     */
+    protected final RegisterConfig registerConfig;
+
+    /**
+     * 构造器
+     */
+    protected AbstractBaseConfigDeclarer() {
+        this.registerConfig = PluginConfigManager.getPluginConfig(RegisterConfig.class);
+    }
+
+    /**
+     * 是否开启双注册, 默认
+     *
+     * @return true 双注册
+     */
+    protected boolean isEnableSpringDoubleRegistry() {
+        return registerConfig.isEnableSpringRegister() && registerConfig.isOpenMigration();
+    }
+}

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/declarers/AbstractDoubleRegistryDeclarer.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/declarers/AbstractDoubleRegistryDeclarer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.huawei.registry.declarers;
+
+/**
+ * 双注册拦截点
+ *
+ * @author zhouss
+ * @since 2022-08-18
+ */
+public abstract class AbstractDoubleRegistryDeclarer extends AbstractBaseConfigDeclarer {
+    @Override
+    public boolean isEnabled() {
+        return isEnableSpringDoubleRegistry();
+    }
+}

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/declarers/DiscoveryClientConfigurationDeclarer.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/declarers/DiscoveryClientConfigurationDeclarer.java
@@ -18,7 +18,6 @@ package com.huawei.registry.declarers;
 
 import com.huawei.registry.interceptors.ClientConfigurationInterceptor;
 
-import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
@@ -29,7 +28,7 @@ import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
  * @author zhouss
  * @since 2021-12-17
  */
-public class DiscoveryClientConfigurationDeclarer extends AbstractPluginDeclarer {
+public class DiscoveryClientConfigurationDeclarer extends AbstractDoubleRegistryDeclarer {
     /**
      * 增强类的全限定名 该client注入优先级最高，因此只需拦截该client即可
      */

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/declarers/DiscoveryClientDeclarer.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/declarers/DiscoveryClientDeclarer.java
@@ -19,7 +19,6 @@ package com.huawei.registry.declarers;
 import com.huawei.registry.interceptors.DiscoveryClientInterceptor;
 import com.huawei.registry.interceptors.DiscoveryClientServiceInterceptor;
 
-import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
@@ -30,7 +29,7 @@ import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
  * @author zhouss
  * @since 2021-12-17
  */
-public class DiscoveryClientDeclarer extends AbstractPluginDeclarer {
+public class DiscoveryClientDeclarer extends AbstractDoubleRegistryDeclarer {
     /**
      * 增强类的全限定名 该client注入优先级最高，因此只需拦截该client即可
      */

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/declarers/DynamicServerListLoadbalancerDeclarer.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/declarers/DynamicServerListLoadbalancerDeclarer.java
@@ -18,7 +18,6 @@ package com.huawei.registry.declarers;
 
 import com.huawei.registry.interceptors.DynamicServerListInterceptor;
 
-import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
@@ -29,7 +28,7 @@ import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
  * @author zhouss
  * @since 2021-12-17
  */
-public class DynamicServerListLoadbalancerDeclarer extends AbstractPluginDeclarer {
+public class DynamicServerListLoadbalancerDeclarer extends AbstractDoubleRegistryDeclarer {
     /**
      * 增强类的全限定名 该client注入优先级最高，因此只需拦截该client即可
      */

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/declarers/cloud3/x/ZookeeperInstanceSupplierDeclarer.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/declarers/cloud3/x/ZookeeperInstanceSupplierDeclarer.java
@@ -16,9 +16,9 @@
 
 package com.huawei.registry.declarers.cloud3.x;
 
+import com.huawei.registry.declarers.AbstractDoubleRegistryDeclarer;
 import com.huawei.registry.interceptors.cloud3.x.ZookeeperInstanceSupplierInterceptor;
 
-import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
@@ -32,7 +32,7 @@ import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
  * @author zhouss
  * @since 2022-03-29
  */
-public class ZookeeperInstanceSupplierDeclarer extends AbstractPluginDeclarer {
+public class ZookeeperInstanceSupplierDeclarer extends AbstractDoubleRegistryDeclarer {
     /**
      * 增强类的全限定名
      */

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/declarers/health/ConsulHealthDeclarer.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/declarers/health/ConsulHealthDeclarer.java
@@ -16,9 +16,9 @@
 
 package com.huawei.registry.declarers.health;
 
+import com.huawei.registry.declarers.AbstractDoubleRegistryDeclarer;
 import com.huawei.registry.interceptors.health.ConsulHealthInterceptor;
 
-import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
@@ -29,7 +29,7 @@ import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
  * @author zhouss
  * @since 2021-12-17
  */
-public class ConsulHealthDeclarer extends AbstractPluginDeclarer {
+public class ConsulHealthDeclarer extends AbstractDoubleRegistryDeclarer {
     /**
      * nacos心跳发送类
      */

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/declarers/health/ConsulWatchConDeclarer.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/declarers/health/ConsulWatchConDeclarer.java
@@ -16,10 +16,10 @@
 
 package com.huawei.registry.declarers.health;
 
+import com.huawei.registry.declarers.AbstractDoubleRegistryDeclarer;
 import com.huawei.registry.interceptors.health.ConsulWatchInterceptor;
 import com.huawei.registry.interceptors.health.ConsulWatchRequestInterceptor;
 
-import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
@@ -30,7 +30,7 @@ import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
  * @author zhouss
  * @since 2021-12-17
  */
-public class ConsulWatchConDeclarer extends AbstractPluginDeclarer {
+public class ConsulWatchConDeclarer extends AbstractDoubleRegistryDeclarer {
     /**
      * nacos心跳发送类
      */

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/declarers/health/EurekaHealthDeclarer.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/declarers/health/EurekaHealthDeclarer.java
@@ -16,10 +16,10 @@
 
 package com.huawei.registry.declarers.health;
 
+import com.huawei.registry.declarers.AbstractDoubleRegistryDeclarer;
 import com.huawei.registry.interceptors.health.EurekaHealthInterceptor;
 import com.huawei.registry.interceptors.health.EurekaRegisterInterceptor;
 
-import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
@@ -30,7 +30,7 @@ import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
  * @author zhouss
  * @since 2021-12-17
  */
-public class EurekaHealthDeclarer extends AbstractPluginDeclarer {
+public class EurekaHealthDeclarer extends AbstractDoubleRegistryDeclarer {
     /**
      * 增强类的全限定名 该client注入优先级最高，因此只需拦截该client即可
      */

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/declarers/health/HealthIndicatorDeclarer.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/declarers/health/HealthIndicatorDeclarer.java
@@ -17,9 +17,9 @@
 
 package com.huawei.registry.declarers.health;
 
+import com.huawei.registry.declarers.AbstractDoubleRegistryDeclarer;
 import com.huawei.registry.interceptors.health.HealthIndicatorInterceptor;
 
-import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
@@ -30,7 +30,7 @@ import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
  * @author zhouss
  * @since 2022-06-13
  */
-public class HealthIndicatorDeclarer extends AbstractPluginDeclarer {
+public class HealthIndicatorDeclarer extends AbstractDoubleRegistryDeclarer {
     /**
      * 健康检查增强类
      */

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/declarers/health/NacosHealthDeclarer.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/declarers/health/NacosHealthDeclarer.java
@@ -16,9 +16,9 @@
 
 package com.huawei.registry.declarers.health;
 
+import com.huawei.registry.declarers.AbstractDoubleRegistryDeclarer;
 import com.huawei.registry.interceptors.health.NacosHealthInterceptor;
 
-import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
@@ -29,7 +29,7 @@ import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
  * @author zhouss
  * @since 2021-12-17
  */
-public class NacosHealthDeclarer extends AbstractPluginDeclarer {
+public class NacosHealthDeclarer extends AbstractDoubleRegistryDeclarer {
     /**
      * nacos心跳发送类
      */

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/declarers/health/ScheduleProcessorDeclared.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/declarers/health/ScheduleProcessorDeclared.java
@@ -17,9 +17,9 @@
 
 package com.huawei.registry.declarers.health;
 
+import com.huawei.registry.declarers.AbstractDoubleRegistryDeclarer;
 import com.huawei.registry.interceptors.health.ScheduleProcessorInterceptor;
 
-import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
@@ -31,7 +31,7 @@ import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
  * @author zhouss
  * @since 2022-06-13
  */
-public class ScheduleProcessorDeclared extends AbstractPluginDeclarer {
+public class ScheduleProcessorDeclared extends AbstractDoubleRegistryDeclarer {
     /**
      * 定时器自动配置类
      */

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/declarers/health/ZookeeperHealthDeclarer.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/declarers/health/ZookeeperHealthDeclarer.java
@@ -16,9 +16,9 @@
 
 package com.huawei.registry.declarers.health;
 
+import com.huawei.registry.declarers.AbstractDoubleRegistryDeclarer;
 import com.huawei.registry.interceptors.health.ZookeeperHealthInterceptor;
 
-import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
@@ -29,7 +29,7 @@ import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
  * @author zhouss
  * @since 2021-12-17
  */
-public class ZookeeperHealthDeclarer extends AbstractPluginDeclarer {
+public class ZookeeperHealthDeclarer extends AbstractDoubleRegistryDeclarer {
     /**
      * nacos心跳发送类
      */

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/interceptors/DiscoveryClientInterceptor.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/interceptors/DiscoveryClientInterceptor.java
@@ -21,6 +21,7 @@ import com.huawei.registry.context.RegisterContext;
 import com.huawei.registry.entity.MicroServiceInstance;
 import com.huawei.registry.services.RegisterCenterService;
 import com.huawei.registry.support.InstanceInterceptorSupport;
+import com.huawei.registry.utils.HostUtils;
 
 import com.huaweicloud.sermant.core.common.LoggerFactory;
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
@@ -84,8 +85,8 @@ public class DiscoveryClientInterceptor extends InstanceInterceptorSupport {
         }
         for (MicroServiceInstance microServiceInstance : microServiceInstances) {
             result.removeIf(originServiceInstance ->
-                    Objects.equals(originServiceInstance.getHost(), microServiceInstance.getHost())
-                            && originServiceInstance.getPort() == microServiceInstance.getPort());
+                    HostUtils.isSameInstance(originServiceInstance.getHost(), originServiceInstance.getPort(),
+                            microServiceInstance.getHost(), microServiceInstance.getPort()));
             buildInstance(microServiceInstance, serviceId)
                     .ifPresent(instance -> result.add((ServiceInstance) instance));
         }

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/interceptors/DynamicServerListInterceptor.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/interceptors/DynamicServerListInterceptor.java
@@ -21,6 +21,7 @@ import com.huawei.registry.entity.MicroServiceInstance;
 import com.huawei.registry.entity.ScServer;
 import com.huawei.registry.services.RegisterCenterService;
 import com.huawei.registry.support.RegisterSwitchSupport;
+import com.huawei.registry.utils.HostUtils;
 
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.service.ServiceManager;
@@ -33,7 +34,6 @@ import com.netflix.loadbalancer.ServerListFilter;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * 针对ribbon serverList拦截, 替换DynamicServerListLoadBalancer定时更新服务的逻辑
@@ -66,8 +66,8 @@ public class DynamicServerListInterceptor extends RegisterSwitchSupport {
         }
         for (MicroServiceInstance microServiceInstance : microServiceInstances) {
             result.removeIf(originServiceInstance ->
-                    Objects.equals(originServiceInstance.getHost(), microServiceInstance.getHost())
-                            && originServiceInstance.getPort() == microServiceInstance.getPort());
+                            HostUtils.isSameInstance(originServiceInstance.getHost(), originServiceInstance.getPort(),
+                                    microServiceInstance.getHost(), microServiceInstance.getPort()));
             result.add(new ScServer(microServiceInstance, serverListLoadBalancer.getName()));
         }
         return result;

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-service/src/main/java/com/huawei/registry/service/client/ScClient.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-service/src/main/java/com/huawei/registry/service/client/ScClient.java
@@ -26,15 +26,14 @@ import com.huawei.registry.service.client.ScDiscovery.SubscriptionKey;
 import com.huawei.registry.service.register.Register;
 import com.huawei.registry.utils.HostUtils;
 
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
 import com.huaweicloud.sermant.core.common.LoggerFactory;
 import com.huaweicloud.sermant.core.plugin.common.PluginConstant;
 import com.huaweicloud.sermant.core.plugin.common.PluginSchemaValidator;
 import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
 import com.huaweicloud.sermant.core.utils.JarFileUtils;
 import com.huaweicloud.sermant.core.utils.StringUtils;
-
-import com.google.common.eventbus.EventBus;
-import com.google.common.eventbus.Subscribe;
 
 import org.apache.servicecomb.foundation.ssl.SSLCustom;
 import org.apache.servicecomb.foundation.ssl.SSLOption;
@@ -409,7 +408,7 @@ public class ScClient {
     private void buildMicroServiceInstance() {
         microserviceInstance = new MicroserviceInstance();
         microserviceInstance.setStatus(MicroserviceInstanceStatus.UP);
-        microserviceInstance.setHostName(HostUtils.getHostName());
+        microserviceInstance.setHostName(RegisterContext.INSTANCE.getClientInfo().getHost());
         microserviceInstance.setEndpoints(buildEndpoints());
         HealthCheck healthCheck = new HealthCheck();
         healthCheck.setMode(HealthCheckMode.push);


### PR DESCRIPTION
【issue号/问题单号/需求单号】#656

【修改内容】
- 适配Spring双注册的declarer开关
- 优化Spring双注册的去重逻辑
- 修正注册时的域名，保持与Spring Cloud保持一致

【用例描述】暂无用例

【自测情况】
测试场景：
（1）通过环境变量修改对应spring开关判断declarer是否正确的加载
（2）在双注册模式，通过注册两个相同的实例，测试相同的实例是否过滤掉，仅剩下一个。

【影响范围】spring注册