### PR TITLE
【feature】优化properties和config.yaml配置文件驼峰和中划线支持以及相应环境变量读取

### DIFF
--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/config/strategy/LoadYamlStrategy.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/config/strategy/LoadYamlStrategy.java
@@ -126,9 +126,13 @@ public class LoadYamlStrategy implements LoadConfigStrategy<Map> {
         Map fixedTypeMap = fixEntry(typeMap, cls.getSuperclass());
         for (Field field : cls.getDeclaredFields()) {
             final ConfigFieldKey configFieldKey = field.getAnnotation(ConfigFieldKey.class);
-            final String fieldKey = configFieldKey == null ? field.getName() : configFieldKey.value();
-            final Object subTypeVal =
-                configFieldKey == null ? fixedTypeMap.get(fieldKey) : fixedTypeMap.remove(fieldKey);
+            final String fieldKey = field.getName();
+            final Object subTypeVal;
+            if (configFieldKey != null && fixedTypeMap.get(configFieldKey.value()) != null) {
+                subTypeVal = fixedTypeMap.remove(configFieldKey.value());
+            } else {
+                subTypeVal = fixedTypeMap.get(fieldKey);
+            }
             if (subTypeVal == null) {
                 continue;
             }
@@ -136,11 +140,11 @@ public class LoadYamlStrategy implements LoadConfigStrategy<Map> {
             if (subTypeVal instanceof Map) {
                 fixedVal = fixEntry((Map) subTypeVal, field.getType());
                 if (configFieldKey != null) {
-                    fixedTypeMap.put(field.getName(), fixedVal);
+                    fixedTypeMap.put(fieldKey, fixedVal);
                 }
             } else {
                 fixedVal = fixValStr(formatConfigKey(fieldKey, cls), fixedTypeMap, subTypeVal);
-                fixedTypeMap.put(field.getName(), fixedVal);
+                fixedTypeMap.put(fieldKey, fixedVal);
             }
         }
         return fixedTypeMap;

--- a/sermant-example/demo-plugin/src/main/java/com/huawei/example/demo/config/DemoConfig.java
+++ b/sermant-example/demo-plugin/src/main/java/com/huawei/example/demo/config/DemoConfig.java
@@ -36,7 +36,11 @@ public class DemoConfig implements PluginConfig { // 有设置拦截器别名需
 
     /**
      * 基础类型配置(除byte和char)
+     *
+     * <p>添加@ConfigFieldKey("int-field")后，config.yaml中配置demo.test.intField或demo.test.int-field皆可</p>
+     * <p>如果不添加注解，config.yaml中只能配置为demo.test.intField</p>
      */
+    @ConfigFieldKey("int-field")
     private int intField;
 
     /**


### PR DESCRIPTION
【issue号/问题单号/需求单号】#649

【修改内容】优化properties和yaml配置文件数据格式支持以及环境变量读取

(1)通过在属性appName上添加@ConfigFieldKey("app-name")注解(举例)，可以在properties或yaml用中划线替换驼峰形式的键值(兼容驼峰形式)。
(2)config.yaml中xxx.xxx.appName将会直接以xxx.xxx.appName和解析为xxx.xxx.app.Name再通过KeyFormatter读取环境变量
(3)config.yaml中xxx.xxx.app-name将会被解析为xxx.xxx.app.Name再通过KeyFormatter读取环境变量

【用例描述】暂无用例

【自测情况】UT测试通过 

【影响范围】config.properties、config.yaml配置
