### PR TITLE
【fix】修复properties和yaml配置文件缺省key时环境变量配置值不生效的问题

### DIFF
--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/config/strategy/LoadPropertiesStrategy.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/config/strategy/LoadPropertiesStrategy.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.List;
@@ -115,6 +116,9 @@ public class LoadPropertiesStrategy implements LoadConfigStrategy<Properties> {
         loadConfig(holder, cls.getSuperclass(), config);
         final String typeKey = ConfigKeyUtil.getTypeKey(cls);
         for (Field field : cls.getDeclaredFields()) {
+            if (Modifier.isFinal(field.getModifiers()) || Modifier.isStatic(field.getModifiers())) {
+                continue;
+            }
             final String key = typeKey + '.' + ConfigKeyUtil.getFieldKey(field);
             final Object value = getConfig(holder, key, field);
             if (value != null) {

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/config/utils/ConfigValueUtil.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/config/utils/ConfigValueUtil.java
@@ -300,10 +300,7 @@ public class ConfigValueUtil {
      */
     public static String fixValue(String configKey, String configVal, Map<String, Object> argsMap,
             FixedValueProvider provider) {
-        if (configVal == null) {
-            return configVal;
-        }
-        if (configVal.matches("^.*\\$\\{[\\w.]+(:.*)?}.*$")) {
+        if (configVal != null && configVal.matches("^.*\\$\\{[\\w.]+(:.*)?}.*$")) {
             final int startIndex = configVal.indexOf("${") + ENV_PREFIX_LEN;
             final int endIndex = configVal.indexOf('}', startIndex);
             final String envKey = configVal.substring(startIndex, endIndex);
@@ -318,12 +315,8 @@ public class ConfigValueUtil {
                     configVal.substring(0, startIndex - ENV_PREFIX_LEN) + value + configVal.substring(endIndex + 1),
                     argsMap, provider);
         } else {
-            final String valFromEnv = getValByFixedKey(configKey, configVal, argsMap);
-            if (valFromEnv != null) {
-                return valFromEnv;
-            }
+            return getValByFixedKey(configKey, configVal, argsMap);
         }
-        return configVal;
     }
 
     /**


### PR DESCRIPTION
【issue号/问题单号/需求单号】#649

【修改内容】修复properties和yaml配置文件缺省key时环境变量配置值不生效的问题
   （1）properties配置文件
      PluginConfig实现类对应的properties配置文件中，基本数据类型/数组/map/list/set缺省key时，支持从启动参数、环境变量、系统变量中依次获取配置值。（环境变量：map需配置为XXX_MAP_NAME=key1:value1,key2:value2格式；数组/list/set需配置为XXX_XXX_LIST_NAME=elem1,elem2。否则环境变量读取后解析失败）
   （2）yaml配置文件
      PluginConfig实现类对应的yaml配置文件中，支持基本数据类型/数组/map/list/set(不支持包含复杂对象)缺省key时从启动参数、环境变量、系统变量中依次获取配置值。（环境变量：map需配置为yaml字符串格式XXX_MAP_NAME={key1: value1, key2: value2}，数组/list/set需配置为yaml字符串格式XXX_XXX_LIST_NAME=[elem1,elem2]。否则环境变量读取后解析失败）

【用例描述】暂无用例

【自测情况】UT测试通过

【影响范围】config.properties、config.yaml配置