### PR TITLE
【fix】修复基于配置中心下发优雅上下线开关存在类找不到的问题

### DIFF
--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/inject/ContextClosedEventListenerInjectDefine.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/inject/ContextClosedEventListenerInjectDefine.java
@@ -40,13 +40,6 @@ public class ContextClosedEventListenerInjectDefine implements ClassInjectDefine
     }
 
     @Override
-    public boolean canInject() {
-        GraceConfig graceConfig = PluginConfigManager.getPluginConfig(GraceConfig.class);
-        return graceConfig.isEnableSpring() && graceConfig.isEnableGraceShutdown() && graceConfig
-            .isEnableOfflineNotify();
-    }
-
-    @Override
     public Plugin plugin() {
         return Plugin.SPRING_REGISTRY_PLUGIN;
     }

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/inject/RequestInterceptorInjectDefine.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/inject/RequestInterceptorInjectDefine.java
@@ -17,9 +17,6 @@
 
 package com.huawei.registry.inject;
 
-import com.huawei.registry.config.GraceConfig;
-
-import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
 import com.huaweicloud.sermant.core.plugin.inject.ClassInjectDefine;
 
 /**
@@ -37,11 +34,6 @@ public class RequestInterceptorInjectDefine implements ClassInjectDefine {
     @Override
     public String factoryName() {
         return "";
-    }
-
-    @Override
-    public boolean canInject() {
-        return PluginConfigManager.getPluginConfig(GraceConfig.class).isEnableSpring();
     }
 
     @Override

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/inject/grace/ContextClosedEventListener.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/inject/grace/ContextClosedEventListener.java
@@ -16,8 +16,10 @@
 
 package com.huawei.registry.inject.grace;
 
+import com.huawei.registry.config.GraceConfig;
 import com.huawei.registry.services.GraceService;
 
+import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
 import com.huaweicloud.sermant.core.plugin.service.PluginServiceManager;
 
 import org.springframework.context.event.ContextClosedEvent;
@@ -45,7 +47,16 @@ public class ContextClosedEventListener {
      * ContextClosedEvent事件监听器
      */
     @EventListener(value = ContextClosedEvent.class)
-    public void listen() {
+    public void listener() {
+        if (!isEnableGraceDown()) {
+            return;
+        }
         graceService.shutdown();
+    }
+
+    private boolean isEnableGraceDown() {
+        GraceConfig graceConfig = PluginConfigManager.getPluginConfig(GraceConfig.class);
+        return graceConfig.isEnableSpring() && graceConfig.isEnableGraceShutdown() && graceConfig
+                .isEnableOfflineNotify();
     }
 }

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/inject/grace/SpringRequestInterceptor.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/inject/grace/SpringRequestInterceptor.java
@@ -43,7 +43,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /**
- * Spring Web请求前置拦截器
+ * Spring Web请求前置拦截器, 由拦截器动态加入, 每次请求都会添加, {@link com.huawei.registry.grace.interceptors.SpringWebHandlerInterceptor}
  *
  * @author zhouss
  * @since 2022-05-23


### PR DESCRIPTION
【issue号/问题单号/需求单号】#664

【修改内容】修复基于配置中心下发优雅上下线开关存在类找不到的问题

【用例描述】暂无用例

【自测情况】本地自测通过
测试场景：
（1）设置应用环境变量关闭优雅上下线功能
（2）在配置中心配置开启优雅上下线功能
（3）测试应用调用，观察是否还存在类找不到的问题

【影响范围】spring优雅上下线
