### PR TITLE
增加注册监控插件

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -283,6 +283,7 @@
             <modules>
                 <module>sermant-agentcore</module>
                 <module>sermant-plugins</module>
+                <module>sermant-backend</module>
             </modules>
         </profile>
         <profile>

--- a/sermant-agentcore/sermant-agentcore-config/config/config.properties
+++ b/sermant-agentcore/sermant-agentcore-config/config/config.properties
@@ -27,3 +27,8 @@ service.meta.application=default
 service.meta.version=1.0.0
 service.meta.project=default
 service.meta.environment=
+
+#monitor config
+monitor.service.address=127.0.0.1
+monitor.service.port=12345
+monitor.service.isStartMonitor=false

--- a/sermant-agentcore/sermant-agentcore-config/config/plugins.yaml
+++ b/sermant-agentcore/sermant-agentcore-config/config/plugins.yaml
@@ -7,6 +7,7 @@ plugins:
   - service-registry
   - loadbalancer
   - dynamic-config
+  - monitor
 adaptors:
   - lubanops
 profiles:

--- a/sermant-agentcore/sermant-agentcore-core/pom.xml
+++ b/sermant-agentcore/sermant-agentcore-core/pom.xml
@@ -76,6 +76,8 @@
         <gpg.plugin.version>3.0.1</gpg.plugin.version>
         <javadoc.plugin.version>3.3.2</javadoc.plugin.version>
         <nexus.staging.plugin.version>1.6.7</nexus.staging.plugin.version>
+
+        <simpleclient.version>0.16.0</simpleclient.version>
     </properties>
 
     <profiles>
@@ -300,6 +302,11 @@
             <version>${asm.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_httpserver</artifactId>
+            <version>${simpleclient.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <extensions>

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/service/monitor/MetricService.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/service/monitor/MetricService.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.core.service.monitor;
+
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+import com.huaweicloud.sermant.core.config.ConfigManager;
+import com.huaweicloud.sermant.core.service.BaseService;
+import com.huaweicloud.sermant.core.service.monitor.config.MonitorConfig;
+
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.exporter.HTTPServer;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.logging.Logger;
+
+/**
+ * 监控插件配置类
+ *
+ * @author zhp
+ * @version 1.0.0
+ * @since 2022-08-02
+ */
+public class MetricService implements BaseService {
+
+    private static HTTPServer httpServer = null;
+
+    /**
+     * 日志
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
+    /**
+     * 初始化监控服务
+     */
+    public void initMonitorServer() {
+        MonitorConfig monitorConfig = ConfigManager.getConfig(MonitorConfig.class);
+        if (monitorConfig == null || !monitorConfig.isStartMonitor()) {
+            return;
+        }
+        InetSocketAddress socketAddress = new InetSocketAddress(monitorConfig.getAddress(), monitorConfig.getPort());
+        try {
+            httpServer = new HTTPServer(socketAddress, CollectorRegistry.defaultRegistry, true);
+        } catch (IOException exception) {
+            LOGGER.warning("could not create httpServer for prometheus");
+        }
+    }
+
+    /**
+     * 启动服务
+     */
+    @Override
+    public void start() {
+        this.initMonitorServer();
+    }
+
+    /**
+     * 服务关闭方法
+     */
+    public void stop() {
+        if (httpServer != null) {
+            httpServer.close();
+        }
+    }
+}

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/service/monitor/config/MonitorConfig.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/service/monitor/config/MonitorConfig.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.core.service.monitor.config;
+
+import com.huaweicloud.sermant.core.config.common.BaseConfig;
+import com.huaweicloud.sermant.core.config.common.ConfigTypeKey;
+
+/**
+ * 监控插件配置类
+ *
+ * @author zhp
+ * @version 1.0.0
+ * @since 2022-08-02
+ */
+@ConfigTypeKey(value = "monitor.service")
+public class MonitorConfig implements BaseConfig {
+
+    /**
+     * 性能监控开关
+     */
+    private boolean isStartMonitor = false;
+
+    /**
+     * 性能监控地址
+     */
+    private String address;
+
+    /**
+     * 性能监控端口
+     */
+    private int port;
+
+    public boolean isStartMonitor() {
+        return isStartMonitor;
+    }
+
+    public void setStartMonitor(boolean startMonitor) {
+        isStartMonitor = startMonitor;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+}

--- a/sermant-agentcore/sermant-agentcore-core/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.config.common.BaseConfig
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.config.common.BaseConfig
@@ -5,3 +5,4 @@ com.huaweicloud.sermant.core.service.dynamicconfig.kie.config.KieDynamicConfig
 com.huaweicloud.sermant.core.service.heartbeat.config.HeartbeatConfig
 com.huaweicloud.sermant.core.plugin.config.ServiceMeta
 com.huaweicloud.sermant.core.service.send.config.BackendConfig
+com.huaweicloud.sermant.core.service.monitor.config.MonitorConfig

--- a/sermant-agentcore/sermant-agentcore-core/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.service.BaseService
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.service.BaseService
@@ -3,3 +3,4 @@ com.huaweicloud.sermant.core.service.send.NettyGatewayClient
 com.huaweicloud.sermant.core.service.dynamicconfig.BufferedDynamicConfigService
 com.huaweicloud.sermant.core.service.tracing.TracingServiceImpl
 com.huaweicloud.sermant.core.plugin.inject.InjectServiceImpl
+com.huaweicloud.sermant.core.service.monitor.MetricService

--- a/sermant-agentcore/sermant-agentcore-core/src/test/java/com/huaweicloud/sermant/core/service/monitor/MetricServiceTest.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/test/java/com/huaweicloud/sermant/core/service/monitor/MetricServiceTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.core.service.monitor;
+
+import com.huaweicloud.sermant.core.config.ConfigManager;
+import com.huaweicloud.sermant.core.service.dynamicconfig.kie.client.http.DefaultHttpClient;
+import com.huaweicloud.sermant.core.service.dynamicconfig.kie.client.http.HttpClient;
+import com.huaweicloud.sermant.core.service.dynamicconfig.kie.client.http.HttpResult;
+import com.huaweicloud.sermant.core.service.monitor.config.MonitorConfig;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 测试HTTPServer
+ *
+ * @author zhp
+ * @since 2022-08-02
+ */
+public class MetricServiceTest {
+
+    private static MetricService metricService;
+
+    private static final String APP_NAME_CODE = "appName";
+
+    private static final String APP_NAME_VALUE = "test";
+
+    private static final String ADDRESS = "127.0.0.1";
+
+    private static final int PORT = 12345;
+
+    private static final int SUCCESS_CODE = 200;
+
+    private static final String URL = "http://127.0.0.1:12345";
+
+    private static MonitorConfig monitorConfig = new MonitorConfig();
+
+    /**
+     * 配置转换器
+     */
+    @BeforeClass
+    public static void setUp() {
+        monitorConfig.setAddress(ADDRESS);
+        monitorConfig.setPort(PORT);
+        monitorConfig.setStartMonitor(true);
+        Mockito.mockStatic(ConfigManager.class)
+                .when(() -> ConfigManager.getConfig(MonitorConfig.class))
+                .thenReturn(monitorConfig);
+    }
+
+    /**
+     * 测试HttpServer
+     */
+    @Test
+    public void testServerSuccess() {
+        Map<String, Object> argsMap = new HashMap<>();
+        argsMap.put(APP_NAME_CODE, APP_NAME_VALUE);
+        metricService = new MetricService();
+        metricService.initMonitorServer();
+        HttpClient httpClient = new DefaultHttpClient();
+        HttpResult result = httpClient.doGet(URL);
+        Assert.assertEquals(result.getCode(), SUCCESS_CODE);
+    }
+
+    /**
+     * 测试HttpServer--开关关闭
+     */
+    @Test
+    public void testServerClose() {
+        monitorConfig.setStartMonitor(false);
+        Map<String, Object> argsMap = new HashMap<>();
+        argsMap.put(APP_NAME_CODE, APP_NAME_VALUE);
+        metricService = new MetricService();
+        metricService.initMonitorServer();
+        HttpClient httpClient = new DefaultHttpClient();
+        HttpResult result = httpClient.doGet(URL);
+        Assert.assertEquals(result.getCode(), HttpResult.ERROR_CODE);
+    }
+}

--- a/sermant-plugins/pom.xml
+++ b/sermant-plugins/pom.xml
@@ -34,6 +34,7 @@
                 <module>sermant-service-registry</module>
                 <module>sermant-dynamic-config</module>
                 <module>sermant-router</module>
+                <module>sermant-monitor</module>
                 <module>sermant-loadbalancer</module>
             </modules>
             <build>

--- a/sermant-plugins/sermant-monitor/monitor-service/pom.xml
+++ b/sermant-plugins/sermant-monitor/monitor-service/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>sermant-monitor</artifactId>
+        <groupId>com.huaweicloud.sermant</groupId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>monitor-service</artifactId>
+
+    <properties>
+        <package.plugin.type>service</package.plugin.type>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.huaweicloud.sermant</groupId>
+            <artifactId>sermant-agentcore-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.7</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <configuration>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
+
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/command/Command.java
+++ b/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/command/Command.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.monitor.command;
+
+/**
+ * 命令
+ *
+ * @author zhp
+ * @version 1.0.0
+ * @since 2022-08-02
+ */
+public class Command {
+
+    /**
+     * CPU使用命令
+     */
+    public static final CpuCommand CPU = new CpuCommand();
+
+    /**
+     * 网络信息命令
+     */
+    public static final NetworkCommand NETWORK = new NetworkCommand();
+
+    /**
+     * 内存信息命令
+     */
+    public static final MemoryCommand MEMORY = new MemoryCommand();
+
+    /**
+     * 磁盘信息命令
+     */
+    public static final DiskCommand DISK = new DiskCommand();
+
+    /**
+     * CPU信息命令
+     */
+    public static final CpuInfoCommand CPU_INFO = new CpuInfoCommand();
+
+    /**
+     * 构造方法
+     */
+    private Command() {
+    }
+}

--- a/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/command/CommandExecutor.java
+++ b/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/command/CommandExecutor.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.monitor.command;
+
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+/**
+ * Linux命令执行器
+ *
+ * @author zhp
+ * @version 1.0.0
+ * @since 2022-08-02
+ */
+public class CommandExecutor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
+    private static final Runtime RUNTIME = Runtime.getRuntime();
+
+    private static final ExecutorService POOL = new ThreadPoolExecutor(2, 10, 0, TimeUnit.SECONDS,
+            new SynchronousQueue<>());
+
+    private CommandExecutor() {
+    }
+
+    /**
+     * 命令执行
+     *
+     * @param command 命令
+     * @param <T>     结果信息
+     * @return 执行结果
+     */
+    public static <T> Optional<T> execute(final MonitorCommand<T> command) {
+        final Process process;
+        try {
+            String[] commands = new String[]{"/bin/sh", "-c", command.getCommand()};
+            process = RUNTIME.exec(commands);
+        } catch (IOException e) {
+            LOGGER.severe("Failed to execute command, " + e.getMessage());
+            return Optional.empty();
+        }
+        final InputStream errorStream = process.getErrorStream();
+        final InputStream inputStream = process.getInputStream();
+        try {
+            CountDownLatch downLatch = new CountDownLatch(1);
+            handleErrorStream(command, errorStream, downLatch);
+            Future<T> parseFuture = parseResult(command, inputStream);
+            process.waitFor();
+            downLatch.await();
+            return Optional.of(parseFuture.get());
+        } catch (InterruptedException | ExecutionException e) {
+            LOGGER.severe("Failed to parse result, " + e.getMessage());
+        } finally {
+            closeStream(errorStream);
+            closeStream(inputStream);
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * 关闭流
+     *
+     * @param inputStream 读入流
+     */
+    private static void closeStream(InputStream inputStream) {
+        try {
+            inputStream.close();
+        } catch (IOException e) {
+            // ignored
+        }
+    }
+
+    /**
+     * 结果解析
+     *
+     * @param command     命令
+     * @param inputStream 读流
+     * @param <T>         结果信息
+     * @return 执行结果
+     */
+    private static <T> Future<T> parseResult(final MonitorCommand<T> command, final InputStream inputStream) {
+        return POOL.submit(new InputHandleTask<>(command::parseResult, inputStream));
+    }
+
+    /**
+     * 错误解析
+     *
+     * @param command     命令
+     * @param errorStream 错误流
+     * @param latch       定时任务
+     * @param <T>         结果
+     */
+    private static <T> void handleErrorStream(final MonitorCommand<T> command, final InputStream errorStream,
+                                              final CountDownLatch latch) {
+        POOL.execute(new ErrorHandleTask(inputStream -> {
+            command.handleError(inputStream);
+            latch.countDown();
+        }, errorStream));
+    }
+
+    /**
+     * 对任务
+     *
+     * @param <T> 命令解析结果
+     * @since 2022-08-02
+     */
+    private static class InputHandleTask<T> implements Callable<T> {
+
+        private final StreamHandler<T> handler;
+
+        private final InputStream inputStream;
+
+        /**
+         * 构造
+         *
+         * @param handler     前置处理
+         * @param inputStream 读入
+         */
+        InputHandleTask(StreamHandler<T> handler, InputStream inputStream) {
+            this.handler = handler;
+            this.inputStream = inputStream;
+        }
+
+        @Override
+        public T call() {
+            return handler.handle(inputStream);
+        }
+    }
+
+    /**
+     * 错误前置任务
+     *
+     * @since 2022-08-02
+     */
+    private static class ErrorHandleTask implements Runnable {
+
+        private final VoidStreamHandler handler;
+
+        private final InputStream inputStream;
+
+        /**
+         * 构造方法
+         *
+         * @param handler     前置处理
+         * @param inputStream 流
+         */
+        ErrorHandleTask(VoidStreamHandler handler, InputStream inputStream) {
+            this.handler = handler;
+            this.inputStream = inputStream;
+        }
+
+        @Override
+        public void run() {
+            handler.handle(inputStream);
+        }
+    }
+
+    /**
+     * Stream 前置处理
+     *
+     * @param <R> 解析结果
+     * @since 2022-08-02
+     */
+    private interface StreamHandler<R> {
+        R handle(InputStream inputStream);
+    }
+
+    /**
+     * 前置处理
+     *
+     * @since 2022-08-02
+     */
+    private interface VoidStreamHandler {
+
+        /**
+         * 前置处理
+         *
+         * @param inputStream 流
+         */
+        void handle(InputStream inputStream);
+    }
+}

--- a/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/command/CommonMonitorCommand.java
+++ b/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/command/CommonMonitorCommand.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.monitor.command;
+
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+import com.huaweicloud.sermant.core.utils.StringUtils;
+
+import org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Logger;
+
+/**
+ * 结果解析抽象类
+ *
+ * @author zhp
+ * @version 1.0.0
+ * @since 2022-08-02
+ * @param <T> 解析结果
+ */
+public abstract class CommonMonitorCommand<T> implements MonitorCommand<T> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
+    private static final int MAX_LOG_LENGTH = 200;
+
+    private static final String ELLIPSIS = "...";
+
+    /**
+     * 对命令执行结果
+     *
+     * @param inputStream 读数据流
+     * @return 命令结果
+     */
+    protected List<String> readLines(InputStream inputStream) {
+        try {
+            return IOUtils.readLines(inputStream, String.valueOf(Charset.defaultCharset()));
+        } catch (IOException e) {
+            LOGGER.severe(String.format("Failed to parse input from subprocess caused by: %s",
+                    e.getMessage()));
+        }
+        return Collections.emptyList();
+    }
+
+    /**
+     * 错误前置处理
+     *
+     * @param errorStream 外部进程错误流
+     */
+    @Override
+    public void handleError(InputStream errorStream) {
+        final List<String> lines = readLines(errorStream);
+        StringBuilder outputBuilder = new StringBuilder();
+        int totalLength = 0;
+        for (String line : lines) {
+            int length = line.length();
+            int newTotalLength = totalLength + length;
+            if (newTotalLength > MAX_LOG_LENGTH) {
+                outputBuilder.append(line, 0, newTotalLength - MAX_LOG_LENGTH)
+                        // if end with punctuation, should remove it first?
+                        .append(ELLIPSIS);
+                break;
+            } else {
+                outputBuilder.append(line);
+                totalLength = newTotalLength;
+            }
+        }
+        if (!StringUtils.isBlank(outputBuilder.toString())) {
+            LOGGER.severe("Subprocess error: " + outputBuilder);
+        }
+    }
+}

--- a/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/command/CpuCommand.java
+++ b/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/command/CpuCommand.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.monitor.command;
+
+import com.huawei.monitor.common.Constants;
+
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.logging.Logger;
+
+/**
+ * CPU实时信息命令
+ *
+ * @author zhp
+ * @version 1.0.0
+ * @since 2022-08-02
+ */
+public class CpuCommand extends CommonMonitorCommand<CpuCommand.CpuStat> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
+    private static final String COMMAND = "cat /proc/stat";
+
+    /**
+     * 采集行前缀
+     */
+    private static final String COLLECT_LINE_PREFIX = "cpu ";
+
+    /**
+     * 各状态列索引
+     */
+    private static final int USER_INDEX = 1;
+    private static final int NICE_INDEX = 2;
+    private static final int SYSTEM_INDEX = 3;
+    private static final int IDLE_INDEX = 4;
+    private static final int IO_WAIT_INDEX = 5;
+
+    @Override
+    public String getCommand() {
+        return COMMAND;
+    }
+
+    /**
+     * 重构泛PaaS类：com.huawei.sermant.plugin.collection.util.CpuParser parse方法
+     */
+    @Override
+    public CpuStat parseResult(InputStream inputStream) {
+        final List<String> lines = readLines(inputStream);
+        for (String line : lines) {
+            if (line.startsWith(COLLECT_LINE_PREFIX)) {
+                String[] stats = line.split(Constants.REGEX_MULTI_SPACES);
+                if (stats.length > IO_WAIT_INDEX) {
+                    return new CpuStat(Long.parseLong(stats[USER_INDEX]), Long.parseLong(stats[NICE_INDEX]),
+                            Long.parseLong(stats[SYSTEM_INDEX]), Long.parseLong(stats[IDLE_INDEX]),
+                            Long.parseLong(stats[IO_WAIT_INDEX]));
+                }
+            }
+        }
+        LOGGER.severe("Illegal result.");
+        return new CpuStat(0L, 0L, 0L, 0L, 0L);
+    }
+
+    /**
+     * CPU信息
+     *
+     * @since 2022-08-02
+     */
+    public static class CpuStat {
+
+        /**
+         * 用户态
+         */
+        private final long user;
+
+        /**
+         * CPU nice信息
+         */
+        private final long nice;
+
+        /**
+         * 系统占用CPU
+         */
+        private final long system;
+
+        /**
+         * CPU空闲情况
+         */
+        private final long idle;
+
+        /**
+         * CPU等待时间
+         */
+        private final long ioWait;
+
+        /**
+         * 构造方法
+         *
+         * @param user   用户态
+         * @param nice   nice信息
+         * @param system 系统占用CPU
+         * @param idle   CPU空闲情况
+         * @param ioWait CPU等待时间
+         */
+        public CpuStat(long user, long nice, long system, long idle, long ioWait) {
+            this.user = user;
+            this.nice = nice;
+            this.system = system;
+            this.idle = idle;
+            this.ioWait = ioWait;
+        }
+
+        public long getUser() {
+            return user;
+        }
+
+        public long getNice() {
+            return nice;
+        }
+
+        public long getSystem() {
+            return system;
+        }
+
+        public long getIdle() {
+            return idle;
+        }
+
+        public long getIoWait() {
+            return ioWait;
+        }
+
+        public long getTotal() {
+            return system + user + nice + idle + ioWait;
+        }
+    }
+}

--- a/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/command/CpuInfoCommand.java
+++ b/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/command/CpuInfoCommand.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.monitor.command;
+
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.logging.Logger;
+
+/**
+ * CPU信息命令
+ *
+ * @author zhp
+ * @version 1.0.0
+ * @since 2022-08-02
+ */
+public class CpuInfoCommand extends CommonMonitorCommand<CpuInfoCommand.CpuInfoStat> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
+    private static final String COMMAND = "cat /proc/cpuinfo | grep 'core id' | uniq |  wc -l";
+
+    @Override
+    public String getCommand() {
+        return COMMAND;
+    }
+
+    /**
+     * 重构泛PaaS类：com.huawei.sermant.plugin.collection.util.CpuParser parse方法
+     */
+    @Override
+    public CpuInfoStat parseResult(InputStream inputStream) {
+        final List<String> lines = readLines(inputStream);
+        int core = 0;
+        for (String line : lines) {
+            core = Integer.parseInt(line);
+        }
+        return new CpuInfoStat(core);
+    }
+
+    /**
+     * CPU信息
+     *
+     * @since 2022-08-02
+     */
+    public static class CpuInfoStat {
+
+        /**
+         * 核心数
+         */
+        private final int totalCores;
+
+        /**
+         * 构造方法
+         *
+         * @param totalCores 核心数
+         */
+        public CpuInfoStat(int totalCores) {
+            this.totalCores = totalCores;
+        }
+
+        public int getTotalCores() {
+            return totalCores;
+        }
+    }
+}

--- a/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/command/DiskCommand.java
+++ b/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/command/DiskCommand.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.monitor.command;
+
+import com.huawei.monitor.common.Constants;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 硬盘命令
+ *
+ * @author zhp
+ * @version 1.0.0
+ * @since 2022-08-02
+ */
+public class DiskCommand extends CommonMonitorCommand<List<DiskCommand.DiskStats>> {
+
+    private static final String COMMAND = "cat /proc/diskstats";
+
+    private static final int DEVICE_NAME_INDEX = 3;
+    private static final int SECTORS_READ_INDEX = 6;
+    private static final int SECTORS_WRITTEN_INDEX = 10;
+    private static final int IO_SPENT_MILLIS_INDEX = 13;
+
+    @Override
+    public String getCommand() {
+        return COMMAND;
+    }
+
+    /**
+     * 重构泛PaaS类：com.huawei.sermant.plugin.collection.util.DiskParser parse方法
+     */
+    @Override
+    public List<DiskStats> parseResult(InputStream inputStream) {
+        final List<String> lines = readLines(inputStream);
+        final List<DiskStats> diskStats = new ArrayList<DiskStats>(lines.size());
+        for (String line : lines) {
+            String[] diskStatsText = line.split(Constants.REGEX_MULTI_SPACES);
+            String deviceName = diskStatsText[DEVICE_NAME_INDEX];
+            long sectorsRead = Long.parseLong(diskStatsText[SECTORS_READ_INDEX]);
+            long sectorWritten = Long.parseLong(diskStatsText[SECTORS_WRITTEN_INDEX]);
+            long ioSpentMillis = Long.parseLong(diskStatsText[IO_SPENT_MILLIS_INDEX]);
+            diskStats.add(new DiskStats(deviceName, sectorsRead, sectorWritten, ioSpentMillis));
+        }
+        return diskStats;
+    }
+
+    /**
+     * 磁盘信息
+     *
+     * @since 2022-08-02
+     */
+    public static final class DiskStats {
+        /**
+         * 3. Device name
+         */
+        private final String deviceName;
+
+        /**
+         * 6. Number of sectors read. This is the total number of sectors read successfully.
+         */
+        private final long sectorsRead;
+
+        /**
+         * 10. Number of sectors written. This is the total number of sectors written successfully.
+         */
+        private final long sectorsWritten;
+
+        /**
+         * 13. Number of milliseconds spent doing I/Os. This field is increased so long as field 9 is nonzero.
+         */
+        private final long ioSpentMillis;
+
+        /**
+         * 构造方法
+         *
+         * @param deviceName 磁盘名称
+         * @param sectorsRead 读磁盘大小
+         * @param sectorsWritten 写洗盘大小
+         * @param ioSpentMillis 耗时
+         */
+        public DiskStats(String deviceName, long sectorsRead, long sectorsWritten, long ioSpentMillis) {
+            this.deviceName = deviceName;
+            this.sectorsRead = sectorsRead;
+            this.sectorsWritten = sectorsWritten;
+            this.ioSpentMillis = ioSpentMillis;
+        }
+
+        public String getDeviceName() {
+            return deviceName;
+        }
+
+        public long getSectorsRead() {
+            return sectorsRead;
+        }
+
+        public long getSectorsWritten() {
+            return sectorsWritten;
+        }
+
+        public long getIoSpentMillis() {
+            return ioSpentMillis;
+        }
+    }
+}

--- a/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/command/MemoryCommand.java
+++ b/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/command/MemoryCommand.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.monitor.command;
+
+import com.huawei.monitor.common.Constants;
+
+import java.io.InputStream;
+import java.util.List;
+
+/**
+ * 内存命令结果解析类
+ *
+ * @author zhp
+ * @version 1.0.0
+ * @since 2022-08-02
+ */
+public class MemoryCommand extends CommonMonitorCommand<MemoryCommand.MemInfo> {
+
+    private static final String COMMAND = "cat /proc/meminfo";
+
+    private static final String MEMORY_TOTAL = "MemTotal";
+    private static final String MEMORY_FREE = "MemFree";
+    private static final String SWAP_CACHED = "SwapCached";
+    private static final String BUFFERS = "Buffers";
+    private static final String CACHED = "Cached";
+
+    @Override
+    public String getCommand() {
+        return COMMAND;
+    }
+
+    /**
+     * 原泛PaaS类：com.huawei.sermant.plugin.collection.util.MemoryParser parse方法
+     */
+    @Override
+    public MemInfo parseResult(InputStream inputStream) {
+        final List<String> lines = readLines(inputStream);
+
+        long memoryTotal = -1L;
+        long memoryFree = -1L;
+        long buffers = -1L;
+        long cached = -1L;
+        long swapCached = -1L;
+
+        for (String line : lines) {
+            String[] memInfo = line.split(Constants.REGEX_MULTI_SPACES);
+            final String category = memInfo[0];
+            final long value = Long.parseLong(memInfo[1]);
+            if (category.startsWith(MEMORY_TOTAL)) {
+                memoryTotal = value;
+            } else if (category.startsWith(MEMORY_FREE)) {
+                memoryFree = value;
+            } else if (category.startsWith(BUFFERS)) {
+                buffers = value;
+            } else if (category.startsWith(CACHED)) {
+                cached = value;
+            } else if (category.startsWith(SWAP_CACHED)) {
+                swapCached = value;
+            }
+        }
+
+        if (memoryTotal < 0 || memoryFree < 0 || buffers < 0) {
+            return new MemInfo(0L, 0L, 0L, 0L, 0L);
+        }
+
+        if (cached < 0 || swapCached < 0) {
+            return new MemInfo(0L, 0L, 0L, 0L, 0L);
+        }
+
+        return new MemInfo(memoryTotal, memoryFree, buffers, cached, swapCached);
+    }
+
+    /**
+     * 内存信息
+     *
+     * @since 2022-08-02
+     */
+    public static class MemInfo {
+
+        /**
+         * 总内存
+         */
+        private final long memoryTotal;
+
+        /**
+         * 空闲内存
+         */
+        private final long memoryFree;
+
+        /**
+         * buffer
+         */
+        private final long buffers;
+
+        /**
+         * 缓存
+         */
+        private final long cached;
+
+        /**
+         * 虚拟缓存
+         */
+        private final long swapCached;
+
+        /**
+         * 构造器
+         *
+         * @param memoryTotal 总内存
+         * @param memoryFree 空闲内存
+         * @param buffers buffer缓存
+         * @param cached 缓存
+         * @param swapCached 虚拟缓存
+         */
+        public MemInfo(long memoryTotal, long memoryFree, long buffers, long cached, long swapCached) {
+            this.memoryTotal = memoryTotal;
+            this.memoryFree = memoryFree;
+            this.buffers = buffers;
+            this.cached = cached;
+            this.swapCached = swapCached;
+        }
+
+        public long getMemoryTotal() {
+            return memoryTotal;
+        }
+
+        public long getMemoryFree() {
+            return memoryFree;
+        }
+
+        public long getBuffers() {
+            return buffers;
+        }
+
+        public long getCached() {
+            return cached;
+        }
+
+        public long getSwapCached() {
+            return swapCached;
+        }
+    }
+}

--- a/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/command/MonitorCommand.java
+++ b/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/command/MonitorCommand.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.monitor.command;
+
+import java.io.InputStream;
+
+/**
+ * Linux监控命令处理接口
+ *
+ * @author zhp
+ * @version 1.0.0
+ * @since 2022-08-02
+ * @param <T> 解析结果
+ */
+public interface MonitorCommand<T> {
+
+    /**
+     * 返回Linux指令
+     *
+     * @return linux指令
+     */
+    String getCommand();
+
+    /**
+     * 结果解析，解析外部进程的输出流
+     *
+     * @param inputStream 外部进程输出流
+     * @return 解析后的结果
+     */
+    T parseResult(InputStream inputStream);
+
+    /**
+     * 错误处理，处理外部进程的错误流
+     *
+     * @param errorStream 外部进程错误流
+     */
+    void handleError(InputStream errorStream);
+}

--- a/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/command/NetworkCommand.java
+++ b/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/command/NetworkCommand.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.monitor.command;
+
+import com.huawei.monitor.common.Constants;
+
+import java.io.InputStream;
+import java.util.List;
+
+/**
+ * 网络命令处理接口
+ *
+ * @author zhp
+ * @version 1.0.0
+ * @since 2022-08-02
+ */
+public class NetworkCommand extends CommonMonitorCommand<NetworkCommand.NetDev> {
+
+    private static final String COMMAND = "cat /proc/net/dev";
+
+    private static final int RECEIVE_BYTE_INDEX = 2;
+    private static final int RECEIVE_PACKETS_INDEX = 3;
+    private static final int TRANSMIT_BYTE_INDEX = 10;
+    private static final int TRANSMIT_PACKETS_INDEX = 11;
+
+    private static final String STATE_SEPARATOR = ":";
+
+    @Override
+    public String getCommand() {
+        return COMMAND;
+    }
+
+    /**
+     * 重构泛PaaS类：com.huawei.sermant.plugin.collection.util.NetWorkParser parse方法
+     */
+    @Override
+    public NetDev parseResult(InputStream inputStream) {
+        final List<String> lines = readLines(inputStream);
+        if (lines.isEmpty()) {
+            return new NetDev(0L, 0L, 0L, 0L);
+        }
+        long receiveBytes = 0L;
+        long transmitBytes = 0L;
+        long receivePackets = 0L;
+        long transmitPackets = 0L;
+        for (String line : lines) {
+            String[] arr = line.split(STATE_SEPARATOR);
+            if (arr.length > 1) {
+                String[] netDev = line.split(Constants.REGEX_MULTI_SPACES);
+                if (netDev.length < TRANSMIT_PACKETS_INDEX) {
+                    continue;
+                }
+                receiveBytes += Long.parseLong(netDev[RECEIVE_BYTE_INDEX]);
+                transmitBytes += Long.parseLong(netDev[TRANSMIT_BYTE_INDEX]);
+                receivePackets += Long.parseLong(netDev[RECEIVE_PACKETS_INDEX]);
+                transmitPackets += Long.parseLong(netDev[TRANSMIT_PACKETS_INDEX]);
+            }
+        }
+        return new NetDev(receiveBytes, transmitBytes, receivePackets, transmitPackets);
+    }
+
+    /**
+     * 网络信息
+     *
+     * @since 2022-08-02
+     */
+    public static class NetDev {
+
+        /**
+         * 读速度
+         */
+        private final long receiveBytes;
+
+        /**
+         * 写速度
+         */
+        private final long receivePackets;
+
+        /**
+         * 读包速度
+         */
+        private final long transmitBytes;
+
+        /**
+         * 写包速度
+         */
+        private final long transmitPackets;
+
+        /**
+         * 构造方法
+         *
+         * @param receiveBytes 读速度
+         * @param receivePackets 写速度
+         * @param transmitBytes 读包速度
+         * @param transmitPackets 写包速度
+         */
+        public NetDev(long receiveBytes, long receivePackets, long transmitBytes, long transmitPackets) {
+            this.receiveBytes = receiveBytes;
+            this.receivePackets = receivePackets;
+            this.transmitBytes = transmitBytes;
+            this.transmitPackets = transmitPackets;
+        }
+
+        public long getReceiveBytes() {
+            return receiveBytes;
+        }
+
+        public long getReceivePackets() {
+            return receivePackets;
+        }
+
+        public long getTransmitBytes() {
+            return transmitBytes;
+        }
+
+        public long getTransmitPackets() {
+            return transmitPackets;
+        }
+    }
+}

--- a/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/common/Constants.java
+++ b/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/common/Constants.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.monitor.common;
+
+/**
+ * 常量类
+ *
+ * @author zhp
+ * @version 1.0.0
+ * @since 2022-08-02
+ */
+public class Constants {
+
+    /**
+     * 分隔符
+     */
+    public static final String REGEX_MULTI_SPACES = "\\s+";
+
+    /**
+     * 构造方法
+     */
+    private Constants() {
+    }
+}

--- a/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/common/MemoryType.java
+++ b/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/common/MemoryType.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.monitor.common;
+
+import java.util.Optional;
+
+/**
+ * JVM内存性能类型
+ *
+ * @author zhp
+ * @version 1.0.0
+ * @since 2022-08-02
+ */
+public enum MemoryType {
+
+    /**
+     * 堆内存
+     */
+    HEAP_MEMORY("heap_memory", MetricEnum.HEAP_MEMORY_INIT, MetricEnum.HEAP_MEMORY_USED, MetricEnum.HEAP_MEMORY_MAX,
+            MetricEnum.HEAP_MEMORY_COMMITTED),
+
+    /**
+     * 非堆内存
+     */
+    NON_HEAP_MEMORY("non_heap_memory", MetricEnum.NON_HEAP_MEMORY_INIT, MetricEnum.NON_HEAP_MEMORY_USED,
+            MetricEnum.NON_HEAP_MEMORY_MAX, MetricEnum.NON_HEAP_MEMORY_COMMITTED),
+
+    /**
+     * CodeCache内存池
+     */
+    CODE_CACHE("Code Cache", MetricEnum.CODE_CACHE_INIT, MetricEnum.CODE_CACHE_USED, MetricEnum.CODE_CACHE_MAX,
+            MetricEnum.CODE_CACHE_COMMITTED),
+
+    /**
+     * Metaspace 内存指标信息
+     */
+    META_SPACE("Metaspace", MetricEnum.META_SPACE_INIT, MetricEnum.META_SPACE_USED, MetricEnum.META_SPACE_MAX,
+            MetricEnum.META_SPACE_COMMITTED),
+
+    /**
+     * 类加载
+     */
+    CLASS_SPACE("Compressed Class Space", MetricEnum.COMPRESSED_CLASS_SPACE_INIT,
+            MetricEnum.COMPRESSED_CLASS_SPACE_USED, MetricEnum.COMPRESSED_CLASS_SPACE_MAX,
+            MetricEnum.COMPRESSED_CLASS_SPACE_COMMITTED),
+    /**
+     * EDEN区指标枚举
+     */
+    EDEN_SPACE("PS Eden Space", MetricEnum.EDEN_INIT, MetricEnum.EDEN_USED, MetricEnum.EDEN_MAX,
+            MetricEnum.EDEN_COMMITTED),
+
+    /**
+     * SURVIVOR指标枚举信息
+     */
+    SURVIVOR_SPACE("PS Survivor Space", MetricEnum.SURVIVOR_INIT, MetricEnum.SURVIVOR_USED, MetricEnum.SURVIVOR_MAX,
+            MetricEnum.SURVIVOR_COMMITTED),
+
+    /**
+     * 老年代指标信息
+     */
+    OLD_GEN_SPACE("PS Old Gen", MetricEnum.OLD_GEN_INIT, MetricEnum.OLD_GEN_USED, MetricEnum.OLD_GEN_MAX,
+            MetricEnum.OLD_GEN_COMMITTED),
+
+    /**
+     * 年轻代指标信息
+     */
+    EDEN_SPACE_CMS("Par Eden Space", MetricEnum.EDEN_INIT, MetricEnum.EDEN_USED, MetricEnum.EDEN_MAX,
+            MetricEnum.EDEN_COMMITTED),
+
+    /**
+     * CMS年轻代指标信息
+     */
+    SURVIVOR_SPACE_CMS("Par Survivor Space", MetricEnum.SURVIVOR_INIT, MetricEnum.SURVIVOR_USED,
+            MetricEnum.SURVIVOR_MAX, MetricEnum.SURVIVOR_COMMITTED),
+
+    /**
+     * 老年代指标枚举
+     */
+    OLD_EDEN_SPACE_CMS("CMS Old Gen", MetricEnum.OLD_GEN_INIT, MetricEnum.OLD_GEN_USED, MetricEnum.OLD_GEN_MAX,
+            MetricEnum.OLD_GEN_COMMITTED);
+
+    /**
+     * 类型
+     */
+    private String type;
+
+    /**
+     * 初始化枚举
+     */
+    private MetricEnum initEnum;
+
+    /**
+     * 使用的枚举
+     */
+    private MetricEnum usedEnum;
+
+    /**
+     * 最大值对应的枚举
+     */
+    private MetricEnum maxEnum;
+
+    /**
+     * 提交值对应的枚举
+     */
+    private MetricEnum committedEnum;
+
+    /**
+     * 构造方法
+     *
+     * @param type          类型
+     * @param initEnum      初始化枚举
+     * @param usedEnum      已使用对应的枚举
+     * @param maxEnum       最大值对应的枚举
+     * @param committedEnum 提交值对应的枚举
+     */
+    MemoryType(String type, MetricEnum initEnum, MetricEnum usedEnum, MetricEnum maxEnum, MetricEnum committedEnum) {
+        this.type = type;
+        this.initEnum = initEnum;
+        this.usedEnum = usedEnum;
+        this.maxEnum = maxEnum;
+        this.committedEnum = committedEnum;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public MetricEnum getInitEnum() {
+        return initEnum;
+    }
+
+    public MetricEnum getUsedEnum() {
+        return usedEnum;
+    }
+
+    public MetricEnum getMaxEnum() {
+        return maxEnum;
+    }
+
+    public MetricEnum getCommittedEnum() {
+        return committedEnum;
+    }
+
+    /**
+     * 获取枚举通过类型
+     *
+     * @param type 类型
+     * @return 对应的枚举
+     */
+    public static Optional<MemoryType> getEnumByType(String type) {
+        for (MemoryType memoryType : MemoryType.values()) {
+            if (memoryType.type.equals(type)) {
+                return Optional.of(memoryType);
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/common/MetricEnum.java
+++ b/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/common/MetricEnum.java
@@ -1,0 +1,341 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.monitor.common;
+
+/**
+ * 性能指标枚举类
+ *
+ * @author zhp
+ * @version 1.0.0
+ * @since 2022-08-02
+ */
+public enum MetricEnum {
+
+    /**
+     * JVM内存指标信息
+     */
+    CPU_USED("cpu_used", "the number is cpu used of jvm"),
+
+    /**
+     * 服务启动时间
+     */
+    START_TIME("start_time", "the number is start time of jvm"),
+
+    /**
+     * 堆内存初始化
+     */
+    HEAP_MEMORY_INIT("heap_memory_init", "the number is init of heap memory"),
+
+    /**
+     * 堆内存最大值
+     */
+    HEAP_MEMORY_MAX("heap_memory_max", "the number is max of heap memory"),
+
+    /**
+     * 堆内存已使用
+     */
+    HEAP_MEMORY_USED("heap_memory_used", "the number is used of heap memory"),
+
+    /**
+     * 堆内存提交值
+     */
+    HEAP_MEMORY_COMMITTED("heap_memory_committed", "the number is committed of heap memory"),
+
+    /**
+     * 非堆内存初始化
+     */
+    NON_HEAP_MEMORY_INIT("non_heap_memory_init", "the number is init of non heap memory"),
+
+    /**
+     * 非堆内存最大值
+     */
+    NON_HEAP_MEMORY_MAX("non_heap_memory_max", "the number is max of non heap memory"),
+
+    /**
+     * 非堆内存使用
+     */
+    NON_HEAP_MEMORY_USED("non_heap_memory_used", "the number is used of non heap memory"),
+
+    /**
+     * 非堆内存提交
+     */
+    NON_HEAP_MEMORY_COMMITTED("non_heap_memory_committed", "the number is committed of non heap memory"),
+
+    /**
+     * codeCache初始值
+     */
+    CODE_CACHE_INIT("code_cache_init", "the number is init of code cache"),
+
+    /**
+     * codecCache 最大值
+     */
+    CODE_CACHE_MAX("code_cache_max", "the number is max of code cache"),
+
+    /**
+     * codeCache使用值
+     */
+    CODE_CACHE_USED("code_cache_used", "the number is used of code cache"),
+
+    /**
+     * codeCache提交值
+     */
+    CODE_CACHE_COMMITTED("code_cache_committed", "the committed is init of code cache"),
+
+    /**
+     * meta space 初始值
+     */
+    META_SPACE_INIT("meta_space_init", "the number is init of meta space"),
+
+    /**
+     * meta space 最大值
+     */
+    META_SPACE_MAX("meta_space_max", "the number is max of meta space"),
+
+    /**
+     * meta space 已使用值
+     */
+    META_SPACE_USED("meta_space_used", "the number is used of meta space"),
+
+    /**
+     * meta space 提交值
+     */
+    META_SPACE_COMMITTED("meta_space_committed", "the committed is init of meta space"),
+
+    /**
+     * class加载初始值
+     */
+    COMPRESSED_CLASS_SPACE_INIT("compressed_class_space_init", "the number is init of compressed class space"),
+
+    /**
+     * class加载最大值
+     */
+    COMPRESSED_CLASS_SPACE_MAX("compressed_class_space_max", "the number is max of compressed class space"),
+
+    /**
+     * class加载器已使用内存
+     */
+    COMPRESSED_CLASS_SPACE_USED("compressed_class_space_used", "the number is used of compressed class space"),
+
+    /**
+     * class加载器已提交内存
+     */
+    COMPRESSED_CLASS_SPACE_COMMITTED("compressed_class_space_committed", "the committed is init of compressed class "
+            + "space"),
+
+    /**
+     * eden区初始化内存
+     */
+    EDEN_INIT("eden_init", "the number is init of eden"),
+
+    /**
+     * eden区内存最大占用
+     */
+    EDEN_MAX("eden_max", "the number is max of eden"),
+
+    /**
+     * eden区已使用内存
+     */
+    EDEN_USED("eden_used", "the number is used of eden"),
+
+    /**
+     * eden区已提交内存
+     */
+    EDEN_COMMITTED("eden_committed", "the committed is init of eden"),
+
+    /**
+     * survivor区初始化内存
+     */
+    SURVIVOR_INIT("survivor_init", "the number is init of survivor"),
+
+    /**
+     * survivor区最大内存占用
+     */
+    SURVIVOR_MAX("survivor_max", "the number is max of survivor"),
+
+    /**
+     * survivor区已使用内存
+     */
+    SURVIVOR_USED("survivor_used", "the number is used of survivor"),
+
+    /**
+     * survivor区已提交占用
+     */
+    SURVIVOR_COMMITTED("survivor_committed", "the committed is init of survivor"),
+
+    /**
+     * 老年代初始化内存占用
+     */
+    OLD_GEN_INIT("old_gen_init", "the number is init of old gen"),
+
+    /**
+     * 老年代最大内存占用
+     */
+    OLD_GEN_MAX("old_gen_max", "the number is max of old gen"),
+
+    /**
+     * 老年代已使用占用
+     */
+    OLD_GEN_USED("old_gen_used", "the number is used of old gen"),
+
+    /**
+     * 老年代已提交内存占用
+     */
+    OLD_GEN_COMMITTED("old_gen_committed", "the committed is init of old gen"),
+
+    /**
+     * 活动线程
+     */
+    THREAD_LIVE("thread_live", "the number is live of thread"),
+
+    /**
+     * 非守护线程
+     */
+    THREAD_PEAK("thread_peak", "the number is peak of thread"),
+
+    /**
+     * 守护线程
+     */
+    THREAD_DAEMON("thread_daemon", "the number is daemon of thread"),
+
+    /**
+     * 年轻代收集次数
+     */
+    NEW_GEN_COUNT("new_gen_count", "the number is count of new gen"),
+
+    /**
+     * 年轻代收集耗时
+     */
+    NEW_GEN_SPEND("new_gen_spend", "the number is spend of new gen"),
+
+    /**
+     * 老年代收集次数
+     */
+    OLD_GEN_COUNT("old_gen_count", "the number is count of new gen"),
+
+    /**
+     * 老年代收集耗时
+     */
+    OLD_GEN_SPEND("old_gen_spend", "the number is spend of new gen"),
+
+    /**
+     * CPU用户态
+     */
+    CPU_USER("cpu_user", "the number is user of cpu"),
+
+    /**
+     * CPU系统
+     */
+    CPU_SYS("cpu_sys", "the number is sys of cpu"),
+
+    /**
+     * CPU等待
+     */
+    CPU_WAIT("cpu_wait", "the number is wait of cpu"),
+
+    /**
+     * CPU空闲
+     */
+    CPU_IDLE("cpu_idle", "the number is idle of cpu"),
+
+    /**
+     * CPU核心数
+     */
+    CPU_CORES("cpu_cores", "the number is cores of cpu"),
+
+    /**
+     * 内存总值
+     */
+    MEMORY_TOTAL("memory_total", "the number is total of memory"),
+
+    /**
+     * SWAP内存大小
+     */
+    MEMORY_SWAP("memory_swap", "the number is swap of memory"),
+
+    /**
+     * BUFFER内存大小
+     */
+    MEMORY_BUFFER("memory_buffer", "the number is buffer of jvm memory"),
+
+    /**
+     * 已使用内存大小
+     */
+    MEMORY_USED("memory_used", "the number is used of jvm memory"),
+
+    /**
+     * 缓存内存大小
+     */
+    MEMORY_CACHE("memory_cached", "the number is cached of memory"),
+
+    /**
+     * 网络读取速度
+     */
+    NETWORK_READ_BYTE_SPEED("network_readBytesPerSec", "the number is read speed of network"),
+
+    /**
+     * 网络写速度
+     */
+    NETWORK_WRITE_BYTE_SPEED("network_writeBytesPerSec", "the number is write speed of network"),
+
+    /**
+     * 网络读包速度
+     */
+    NETWORK_READ_PACKAGE_SPEED("network_readPackagePerSec", "the number is read package speed of network"),
+
+    /**
+     * 网络写包速度
+     */
+    NETWORK_WRITE_PACKAGE_SPEED("network_writePackagePerSec", "the number is cached of memory"),
+
+    /**
+     * 磁盘读速度
+     */
+    DISK_READ_BYTE_SPEED("disk_readBytesPerSec", "the number is read byte speed of disk"),
+
+    /**
+     * 磁盘写速度
+     */
+    DISK_WRITE_BYTE_SPEED("disk_writeBytesPerSec", "the number is buffer of memory"),
+
+    /**
+     * 磁盘繁忙情况
+     */
+    DISK_IO_SPENT("disk_ioSpentPercentage", "the number is used of memory");
+
+    /**
+     * 名称
+     */
+    private String name;
+
+    /**
+     * 描述
+     */
+    private String disc;
+
+    MetricEnum(String name, String disc) {
+        this.name = name;
+        this.disc = disc;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDisc() {
+        return disc;
+    }
+}

--- a/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/common/MetricFamilyBuild.java
+++ b/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/common/MetricFamilyBuild.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.monitor.common;
+
+import io.prometheus.client.GaugeMetricFamily;
+
+/**
+ * MetricFamily 构造类
+ *
+ * @author zhp
+ * @version 1.0.0
+ * @since 2022-08-02
+ */
+public class MetricFamilyBuild {
+
+    /**
+     * 构造方法
+     */
+    private MetricFamilyBuild() {
+    }
+
+    /**
+     * 构造 GaugeMetric
+     *
+     * @param metricEnum 指标枚举信息
+     * @param value 指标值
+     * @return 创建的收集指标
+     */
+    public static GaugeMetricFamily buildGaugeMetric(MetricEnum metricEnum, double value) {
+        return new GaugeMetricFamily(metricEnum.getName(), metricEnum.getDisc(), value);
+    }
+}

--- a/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/service/JvmCollectorService.java
+++ b/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/service/JvmCollectorService.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.monitor.service;
+
+import com.huawei.monitor.common.MemoryType;
+import com.huawei.monitor.common.MetricEnum;
+import com.huawei.monitor.common.MetricFamilyBuild;
+import com.huawei.monitor.util.CollectionUtil;
+
+import com.huaweicloud.sermant.core.plugin.service.PluginService;
+
+import com.sun.management.OperatingSystemMXBean;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.GaugeMetricFamily;
+
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.MemoryPoolMXBean;
+import java.lang.management.MemoryUsage;
+import java.lang.management.ThreadMXBean;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * JVM性能指标采集器
+ *
+ * @author zhp
+ * @version 1.0.0
+ * @since 2022-08-02
+ */
+public class JvmCollectorService extends Collector implements PluginService {
+
+    private static final List<String> NEW_GEN_NAME_LIST = Arrays.asList("PS Scavenge", "PaeNew");
+
+    private static final int PERCENT = 100;
+
+    @Override
+    public void start() {
+        this.register();
+    }
+
+    @Override
+    public List<MetricFamilySamples> collect() {
+        List<MetricFamilySamples> metricFamilySamplesList = new ArrayList<>();
+        OperatingSystemMXBean operatingSystemMxBean =
+                (OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean();
+        GaugeMetricFamily gaugeMetricFamily = MetricFamilyBuild.buildGaugeMetric(MetricEnum.CPU_USED,
+                operatingSystemMxBean.getProcessCpuLoad() * PERCENT);
+        metricFamilySamplesList.add(gaugeMetricFamily);
+        MemoryMXBean memoryMxBean = ManagementFactory.getMemoryMXBean();
+        fillMetric(metricFamilySamplesList, MemoryType.HEAP_MEMORY.getType(), memoryMxBean.getHeapMemoryUsage());
+        fillMetric(metricFamilySamplesList, MemoryType.NON_HEAP_MEMORY.getType(), memoryMxBean.getNonHeapMemoryUsage());
+        fillGcMetric(metricFamilySamplesList, ManagementFactory.getGarbageCollectorMXBeans());
+        fillThreadMetric(metricFamilySamplesList, ManagementFactory.getThreadMXBean());
+        fillMemoryMetric(metricFamilySamplesList, ManagementFactory.getMemoryPoolMXBeans());
+        GaugeMetricFamily startTimeMetric = MetricFamilyBuild.buildGaugeMetric(MetricEnum.START_TIME,
+                System.currentTimeMillis() - ManagementFactory.getRuntimeMXBean().getStartTime());
+        metricFamilySamplesList.add(startTimeMetric);
+        return metricFamilySamplesList;
+    }
+
+    /**
+     * 填充GC指标信息
+     *
+     * @param metricList 指标收集集合
+     * @param gcMxBeans  GC信息
+     */
+    private void fillGcMetric(List<MetricFamilySamples> metricList, List<GarbageCollectorMXBean> gcMxBeans) {
+        if (CollectionUtil.isEmpty(gcMxBeans)) {
+            return;
+        }
+        gcMxBeans.forEach(gcMxBean -> {
+            if (NEW_GEN_NAME_LIST.contains(gcMxBean.getName())) {
+                metricList.add(MetricFamilyBuild.buildGaugeMetric(MetricEnum.NEW_GEN_COUNT,
+                        gcMxBean.getCollectionCount()));
+                metricList.add(MetricFamilyBuild.buildGaugeMetric(MetricEnum.NEW_GEN_SPEND,
+                        gcMxBean.getCollectionTime()));
+            } else {
+                metricList.add(MetricFamilyBuild.buildGaugeMetric(MetricEnum.OLD_GEN_COUNT,
+                        gcMxBean.getCollectionCount()));
+                metricList.add(MetricFamilyBuild.buildGaugeMetric(MetricEnum.OLD_GEN_SPEND,
+                        gcMxBean.getCollectionTime()));
+            }
+        });
+    }
+
+    /**
+     * 填充内存指标信息
+     *
+     * @param metricList        指标信息集合
+     * @param memoryPoolMxBeans 内存指标信息
+     */
+    private void fillMemoryMetric(List<MetricFamilySamples> metricList, List<MemoryPoolMXBean> memoryPoolMxBeans) {
+        if (CollectionUtil.isEmpty(memoryPoolMxBeans)) {
+            return;
+        }
+        memoryPoolMxBeans.forEach(memoryPoolMxBean -> {
+            if (memoryPoolMxBean.getUsage() != null) {
+                fillMetric(metricList, memoryPoolMxBean.getName(), memoryPoolMxBean.getUsage());
+            }
+        });
+    }
+
+    /**
+     * 收集线程指标信息
+     *
+     * @param metricList   性能指标信息
+     * @param threadMxBean 线程信息
+     */
+    private void fillThreadMetric(List<MetricFamilySamples> metricList, ThreadMXBean threadMxBean) {
+        metricList.add(MetricFamilyBuild.buildGaugeMetric(MetricEnum.THREAD_LIVE, threadMxBean.getThreadCount()));
+        metricList.add(MetricFamilyBuild.buildGaugeMetric(MetricEnum.THREAD_DAEMON,
+                threadMxBean.getDaemonThreadCount()));
+        metricList.add(MetricFamilyBuild.buildGaugeMetric(MetricEnum.THREAD_PEAK, threadMxBean.getPeakThreadCount()));
+    }
+
+    /**
+     * 填充内存指标
+     *
+     * @param metricFamilySamplesList 指标集合
+     * @param type                    类型
+     * @param memoryUsage             指标信息
+     */
+    private void fillMetric(List<MetricFamilySamples> metricFamilySamplesList, String type, MemoryUsage memoryUsage) {
+        Optional<MemoryType> optional = MemoryType.getEnumByType(type);
+        if (!optional.isPresent()) {
+            return;
+        }
+        MemoryType memoryType = optional.get();
+        metricFamilySamplesList.add(MetricFamilyBuild.buildGaugeMetric(memoryType.getInitEnum(),
+                memoryUsage.getInit()));
+        metricFamilySamplesList.add(MetricFamilyBuild.buildGaugeMetric(memoryType.getMaxEnum(), memoryUsage.getMax()));
+        metricFamilySamplesList.add(MetricFamilyBuild.buildGaugeMetric(memoryType.getUsedEnum(),
+                memoryUsage.getUsed()));
+        metricFamilySamplesList.add(MetricFamilyBuild.buildGaugeMetric(memoryType.getCommittedEnum(),
+                memoryUsage.getCommitted()));
+    }
+}

--- a/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/service/ServerCollectorService.java
+++ b/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/service/ServerCollectorService.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.monitor.service;
+
+import com.huawei.monitor.command.Command;
+import com.huawei.monitor.command.CommandExecutor;
+import com.huawei.monitor.command.CpuCommand;
+import com.huawei.monitor.command.CpuInfoCommand;
+import com.huawei.monitor.command.DiskCommand;
+import com.huawei.monitor.command.MemoryCommand;
+import com.huawei.monitor.command.NetworkCommand;
+import com.huawei.monitor.common.MetricEnum;
+import com.huawei.monitor.common.MetricFamilyBuild;
+
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+import com.huaweicloud.sermant.core.plugin.service.PluginService;
+
+import io.prometheus.client.Collector;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+/**
+ * 服务器性能指标采集器
+ *
+ * @author zhp
+ * @version 1.0.0
+ * @since 2022-08-02
+ */
+public class ServerCollectorService extends Collector implements PluginService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
+    private static final BigDecimal HUNDRED = new BigDecimal("100");
+
+    private static final long INTERVAL = 1L;
+
+    private static final int SCALE = 0;
+
+    private static final int BYTES_PER_SECTOR = 512;
+
+    private static final int IO_SPENT_SCALE = 2;
+
+    private static final int MILLIS = 1000;
+
+    @Override
+    public void start() {
+        this.register();
+    }
+
+    @Override
+    public List<MetricFamilySamples> collect() {
+        List<MetricFamilySamples> metricFamilySamplesList = new ArrayList<>();
+        collectMemoryMetric(metricFamilySamplesList);
+        Optional<CpuCommand.CpuStat> cpuStatOptional = CommandExecutor.execute(Command.CPU);
+        Optional<NetworkCommand.NetDev> netDevOptional = CommandExecutor.execute(Command.NETWORK);
+        Optional<List<DiskCommand.DiskStats>> diskStatsListOptional = CommandExecutor.execute(Command.DISK);
+        collectCpuMetric(metricFamilySamplesList, cpuStatOptional);
+        collectNetWorkMetric(metricFamilySamplesList, netDevOptional);
+        collectDiskMetric(metricFamilySamplesList, diskStatsListOptional);
+        Optional<CpuInfoCommand.CpuInfoStat> cpuInfoStatOptional = CommandExecutor.execute(Command.CPU_INFO);
+        cpuInfoStatOptional.ifPresent(cpuInfoStat -> metricFamilySamplesList.add(MetricFamilyBuild.buildGaugeMetric(
+                MetricEnum.CPU_CORES, cpuInfoStat.getTotalCores())));
+        return metricFamilySamplesList;
+    }
+
+    private static void sleep() {
+        try {
+            Thread.sleep(INTERVAL * MILLIS);
+        } catch (InterruptedException e) {
+            LOGGER.warning("thread sleep is interrupted");
+        }
+    }
+
+    private void collectDiskMetric(List<MetricFamilySamples> metricList,
+                                   Optional<List<DiskCommand.DiskStats>> statsListOptional) {
+        Optional<List<DiskCommand.DiskStats>> currentStatsListOptional = CommandExecutor.execute(Command.DISK);
+        if (!statsListOptional.isPresent() || (!currentStatsListOptional.isPresent())) {
+            return;
+        }
+        List<DiskCommand.DiskStats> statsList = statsListOptional.get();
+        List<DiskCommand.DiskStats> currentStatsList = currentStatsListOptional.get();
+        Map<String, DiskCommand.DiskStats> map = new HashMap<>();
+        statsList.forEach(stats -> map.put(stats.getDeviceName(), stats));
+        double totalSectorsRead = 0L;
+        double totalSectorsWritten = 0L;
+        double totalIoSpent = 0L;
+        for (DiskCommand.DiskStats currentStats : currentStatsList) {
+            DiskCommand.DiskStats stats = map.get(currentStats.getDeviceName());
+            if (stats != null) {
+                totalSectorsRead += currentStats.getSectorsRead() - stats.getSectorsRead();
+                totalSectorsWritten += currentStats.getSectorsWritten() - stats.getSectorsWritten();
+                totalIoSpent += currentStats.getIoSpentMillis() - stats.getIoSpentMillis();
+            } else {
+                totalSectorsRead += currentStats.getSectorsRead();
+                totalSectorsWritten += currentStats.getSectorsWritten();
+                totalIoSpent += currentStats.getIoSpentMillis();
+            }
+        }
+        metricList.add(MetricFamilyBuild.buildGaugeMetric(MetricEnum.DISK_READ_BYTE_SPEED,
+                totalSectorsRead * BYTES_PER_SECTOR / INTERVAL));
+        metricList.add(MetricFamilyBuild.buildGaugeMetric(MetricEnum.DISK_WRITE_BYTE_SPEED,
+                totalSectorsWritten * BYTES_PER_SECTOR / INTERVAL));
+        long divideNum = INTERVAL * MILLIS * currentStatsList.size();
+        metricList.add(MetricFamilyBuild.buildGaugeMetric(MetricEnum.DISK_IO_SPENT,
+                getPercentage(totalIoSpent, divideNum, IO_SPENT_SCALE).doubleValue()));
+    }
+
+    private void collectNetWorkMetric(List<MetricFamilySamples> metricFamilySamplesList,
+                                      Optional<NetworkCommand.NetDev> netDevOptional) {
+        Optional<NetworkCommand.NetDev> currentNetDevOptional = CommandExecutor.execute(Command.NETWORK);
+        if (!netDevOptional.isPresent() || (!currentNetDevOptional.isPresent())) {
+            return;
+        }
+        NetworkCommand.NetDev currentNetDev = currentNetDevOptional.get();
+        NetworkCommand.NetDev netDev = netDevOptional.get();
+        long readBytesSpeed = (currentNetDev.getReceiveBytes() - netDev.getReceiveBytes()) / INTERVAL;
+        long writeBytesSpeed = (currentNetDev.getTransmitBytes() - netDev.getTransmitBytes()) / INTERVAL;
+        long readPackageSpeed = (currentNetDev.getReceivePackets() - netDev.getReceivePackets()) / INTERVAL;
+        long writePackageSpeed = (currentNetDev.getTransmitPackets() - netDev.getTransmitPackets()) / INTERVAL;
+        metricFamilySamplesList.add(MetricFamilyBuild.buildGaugeMetric(MetricEnum.NETWORK_READ_BYTE_SPEED,
+                readBytesSpeed));
+        metricFamilySamplesList.add(MetricFamilyBuild.buildGaugeMetric(MetricEnum.NETWORK_WRITE_BYTE_SPEED,
+                writeBytesSpeed));
+        metricFamilySamplesList.add(MetricFamilyBuild.buildGaugeMetric(MetricEnum.NETWORK_READ_PACKAGE_SPEED,
+                readPackageSpeed));
+        metricFamilySamplesList.add(MetricFamilyBuild.buildGaugeMetric(MetricEnum.NETWORK_WRITE_PACKAGE_SPEED,
+                writePackageSpeed));
+    }
+
+    private void collectMemoryMetric(List<MetricFamilySamples> metricFamilySamplesList) {
+        Optional<MemoryCommand.MemInfo> memInfoOptional = CommandExecutor.execute(Command.MEMORY);
+        if (!memInfoOptional.isPresent()) {
+            return;
+        }
+        MemoryCommand.MemInfo memInfo = memInfoOptional.get();
+        metricFamilySamplesList.add(MetricFamilyBuild.buildGaugeMetric(MetricEnum.MEMORY_USED,
+                memInfo.getMemoryTotal() - memInfo.getMemoryFree() - memInfo.getBuffers() - memInfo.getCached()));
+        metricFamilySamplesList.add(MetricFamilyBuild.buildGaugeMetric(MetricEnum.MEMORY_TOTAL,
+                memInfo.getMemoryTotal()));
+        metricFamilySamplesList.add(MetricFamilyBuild.buildGaugeMetric(MetricEnum.MEMORY_BUFFER, memInfo.getBuffers()));
+        metricFamilySamplesList.add(MetricFamilyBuild.buildGaugeMetric(MetricEnum.MEMORY_SWAP,
+                memInfo.getSwapCached()));
+        metricFamilySamplesList.add(MetricFamilyBuild.buildGaugeMetric(MetricEnum.MEMORY_CACHE, memInfo.getCached()));
+    }
+
+    /**
+     * 收集CPU指标信息 两次指标取差值
+     *
+     * @param metricFamilySamplesList 指标信息集合
+     * @param cpuStatOptional         cpu信息
+     */
+    private void collectCpuMetric(List<MetricFamilySamples> metricFamilySamplesList,
+                                  Optional<CpuCommand.CpuStat> cpuStatOptional) {
+        sleep();
+        Optional<CpuCommand.CpuStat> currentCpuStatOptional = CommandExecutor.execute(Command.CPU);
+        if (!cpuStatOptional.isPresent() || (!currentCpuStatOptional.isPresent())) {
+            return;
+        }
+        CpuCommand.CpuStat currentCpuStat = currentCpuStatOptional.get();
+        CpuCommand.CpuStat cpuStat = cpuStatOptional.get();
+        long idleAdd = currentCpuStat.getIdle() - cpuStat.getIdle();
+        long totalAdd = currentCpuStat.getTotal() - cpuStat.getTotal();
+        long waitAdd = currentCpuStat.getIoWait() - cpuStat.getIoWait();
+        long sysAdd = currentCpuStat.getSystem() - cpuStat.getSystem();
+        long userAdd = currentCpuStat.getUser() - cpuStat.getUser() + currentCpuStat.getNice() - cpuStat.getNice();
+        metricFamilySamplesList.add(MetricFamilyBuild.buildGaugeMetric(MetricEnum.CPU_USER, getPercentage(userAdd,
+                totalAdd, SCALE).doubleValue()));
+        metricFamilySamplesList.add(MetricFamilyBuild.buildGaugeMetric(MetricEnum.CPU_IDLE, getPercentage(idleAdd,
+                totalAdd, SCALE).doubleValue()));
+        metricFamilySamplesList.add(MetricFamilyBuild.buildGaugeMetric(MetricEnum.CPU_WAIT, getPercentage(waitAdd,
+                totalAdd, SCALE).doubleValue()));
+        metricFamilySamplesList.add(MetricFamilyBuild.buildGaugeMetric(MetricEnum.CPU_SYS, getPercentage(sysAdd,
+                totalAdd, SCALE).doubleValue()));
+    }
+
+    private static BigDecimal getPercentage(double numerate, long denominator, int scale) {
+        return BigDecimal.valueOf(numerate).multiply(HUNDRED).divide(BigDecimal.valueOf(denominator), scale,
+                RoundingMode.HALF_UP);
+    }
+}

--- a/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/util/CollectionUtil.java
+++ b/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/util/CollectionUtil.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.monitor.util;
+
+import java.util.List;
+
+/**
+ * 集合工具类
+ *
+ * @author zhp
+ * @version 1.0.0
+ * @since 2022-08-02
+ */
+public class CollectionUtil {
+
+    private CollectionUtil() {
+    }
+
+    /**
+     * 是否为空
+     *
+     * @param list 集合
+     * @return 判断结果
+     */
+    public static boolean isEmpty(List list) {
+        return list == null || list.isEmpty();
+    }
+}

--- a/sermant-plugins/sermant-monitor/monitor-service/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.service.PluginService
+++ b/sermant-plugins/sermant-monitor/monitor-service/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.service.PluginService
@@ -1,0 +1,2 @@
+com.huawei.monitor.service.JvmCollectorService
+com.huawei.monitor.service.ServerCollectorService

--- a/sermant-plugins/sermant-monitor/monitor-service/src/test/java/com/huawei/monitor/CollectorServiceTest.java
+++ b/sermant-plugins/sermant-monitor/monitor-service/src/test/java/com/huawei/monitor/CollectorServiceTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.huawei.monitor;
+
+import com.huawei.monitor.service.JvmCollectorService;
+import com.huawei.monitor.service.ServerCollectorService;
+import com.huawei.monitor.util.CollectionUtil;
+
+import io.netty.util.internal.StringUtil;
+import io.prometheus.client.Collector;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+/**
+ * 测试性能指标收集
+ *
+ * @author zhp
+ * @since 2022-08-02
+ */
+public class CollectorServiceTest {
+
+    private static JvmCollectorService jvmCollectorService;
+
+    private static ServerCollectorService serverCollectorService;
+
+    private static final String OS_NAME_CODE = "os.name";
+
+    private static final String LINUX__OS_NAME = "Linux";
+
+    /**
+     * 测试能否正常获取JVM性能指标
+     */
+    @Test
+    public void testJvm() {
+        jvmCollectorService = new JvmCollectorService();
+        List<Collector.MetricFamilySamples> metricFamilySamplesList = jvmCollectorService.collect();
+        Assert.assertFalse(CollectionUtil.isEmpty(metricFamilySamplesList));
+        metricFamilySamplesList.forEach(samplesList -> {
+            Assert.assertNotNull(samplesList);
+            Assert.assertFalse(CollectionUtil.isEmpty(samplesList.samples));
+            samplesList.samples.forEach(sample -> {
+                Assert.assertNotNull(sample.name);
+                Assert.assertNotNull(sample.value);
+            });
+        });
+        String osName = System.getProperty(OS_NAME_CODE);
+        if (!StringUtil.isNullOrEmpty(osName) && osName.startsWith(LINUX__OS_NAME)) {
+            serverCollectorService = new ServerCollectorService();
+            List<Collector.MetricFamilySamples> serverMetricFamilySamples = serverCollectorService.collect();
+            Assert.assertFalse(CollectionUtil.isEmpty(serverMetricFamilySamples));
+            serverMetricFamilySamples.forEach(samplesList -> {
+                Assert.assertNotNull(samplesList);
+                Assert.assertFalse(CollectionUtil.isEmpty(samplesList.samples));
+                samplesList.samples.forEach(sample -> {
+                    Assert.assertNotNull(sample.name);
+                    Assert.assertNotNull(sample.value);
+                });
+            });
+        }
+    }
+}

--- a/sermant-plugins/sermant-monitor/pom.xml
+++ b/sermant-plugins/sermant-monitor/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>sermant-plugins</artifactId>
+        <groupId>com.huaweicloud.sermant</groupId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>pom</packaging>
+
+    <artifactId>sermant-monitor</artifactId>
+
+    <properties>
+        <sermant.basedir>${pom.basedir}/../../..</sermant.basedir>
+        <package.plugin.name>monitor</package.plugin.name>
+
+        <simpleclient.version>0.16.0</simpleclient.version>
+    </properties>
+
+    <profiles>
+        <profile>
+            <id>agent</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>monitor-service</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>ext</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>monitor-service</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>all</id>
+            <modules>
+                <module>monitor-service</module>
+            </modules>
+        </profile>
+    </profiles>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.prometheus</groupId>
+                <artifactId>simpleclient</artifactId>
+                <version>${simpleclient.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+</project>


### PR DESCRIPTION
【issue号/问题单号/需求单号】#665

【修改内容】增加注册监控插件

【用例描述】暂无用例

【自测情况】1、本地自测通过
测试场景：
1、测试应用启动情况下监控插件数据和visual vm数据一致性
2、测试linux服务器下服务器性能信息和TOP等命令下的数据一致性。

【影响范围】
1、性能监控插件