### PR TITLE
【fix】基于动态方式提升动态配置优先级，确保动态关闭场景新的配置中心配置生效

### DIFF
--- a/.github/workflows/intergration_spring_test.yml
+++ b/.github/workflows/intergration_spring_test.yml
@@ -8,9 +8,23 @@ on:
       - main
       - develop
 jobs:
+  download-cse-and-upload:
+    name: download cse and upload
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: download cse and upload
+        run: |
+          export ROOT_PATH=$(pwd)
+          bash ./sermant-integration-tests/scripts/downloadCse.sh
+      - uses: actions/upload-artifact@v3
+        with:
+          name: local-cse
+          path: Local-CSE-2.1.3-linux-amd64.zip
   test-for-spring-1-5-x:
     name: Test for spring 1.5.x
     runs-on: ubuntu-latest
+    needs: [download-cse-and-upload]
     strategy:
       matrix:
         include:
@@ -25,10 +39,14 @@ jobs:
           java-version: '8'
           distribution: 'adopt'
           cache: maven
-      - name: download localcse and run
+      - name: download-cse
+        uses: actions/download-artifact@v3
+        with:
+          name: local-cse
+      - name: start cse
         run: |
           export ROOT_PATH=$(pwd)
-          bash ./sermant-integration-tests/scripts/downloadAndStartCse.sh
+          bash ./sermant-integration-tests/scripts/startCse.sh
       - name: download zookeeper and run
         run: |
           curl -o apache-zookeeper-3.6.3-bin.tar.gz -L https://dlcdn.apache.org/zookeeper/zookeeper-3.6.3/apache-zookeeper-3.6.3-bin.tar.gz
@@ -67,6 +85,7 @@ jobs:
   test-for-spring:
     name: Test for spring
     runs-on: ubuntu-latest
+    needs: [download-cse-and-upload]
     strategy:
       matrix:
         include:
@@ -93,15 +112,26 @@ jobs:
           java-version: '8'
           distribution: 'adopt'
           cache: maven
-      - name: download localcse and run
+      - name: download-cse
+        uses: actions/download-artifact@v3
+        with:
+          name: local-cse
+      - name: start cse
         run: |
           export ROOT_PATH=$(pwd)
-          bash ./sermant-integration-tests/scripts/downloadAndStartCse.sh
+          bash ./sermant-integration-tests/scripts/startCse.sh
       - name: download zookeeper and run
         run: |
           curl -o apache-zookeeper-3.6.3-bin.tar.gz -L https://dlcdn.apache.org/zookeeper/zookeeper-3.6.3/apache-zookeeper-3.6.3-bin.tar.gz
           tar -zxf apache-zookeeper-3.6.3-bin.tar.gz
           bash apache-zookeeper-3.6.3-bin/bin/zkServer.sh start apache-zookeeper-3.6.3-bin/conf/zoo_sample.cfg
+      - name: cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: package agent
         run: mvn package -DskipTests -Pagent --file pom.xml
       - name: package common demos
@@ -135,6 +165,7 @@ jobs:
   test-for-spring-nacos-config:
     name: Test for spring nacos config
     runs-on: ubuntu-latest
+    needs: [download-cse-and-upload]
     strategy:
       matrix:
         include:
@@ -173,10 +204,21 @@ jobs:
           curl -o nacos-server-1.4.2.tar.gz -L https://github.com/alibaba/nacos/releases/download/1.4.2/nacos-server-1.4.2.tar.gz
           tar -zxf nacos-server-1.4.2.tar.gz
           bash nacos/bin/startup.sh -m standalone
-      - name: download localcse and run
+      - name: download-cse
+        uses: actions/download-artifact@v3
+        with:
+          name: local-cse
+      - name: start cse
         run: |
           export ROOT_PATH=$(pwd)
-          bash ./sermant-integration-tests/scripts/downloadAndStartCse.sh
+          bash ./sermant-integration-tests/scripts/startCse.sh
+      - name: cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: package agent
         run: mvn package -DskipTests -Pagent --file pom.xml
       - name: package spring nacos config
@@ -219,6 +261,7 @@ jobs:
   test-for-spring-zk-config:
     name: Test for spring zk config
     runs-on: ubuntu-latest
+    needs: [download-cse-and-upload]
     strategy:
       matrix:
         include:
@@ -252,10 +295,21 @@ jobs:
           curl -o apache-zookeeper-3.6.3-bin.tar.gz -L https://dlcdn.apache.org/zookeeper/zookeeper-3.6.3/apache-zookeeper-3.6.3-bin.tar.gz
           tar -zxf apache-zookeeper-3.6.3-bin.tar.gz
           bash apache-zookeeper-3.6.3-bin/bin/zkServer.sh start apache-zookeeper-3.6.3-bin/conf/zoo_sample.cfg
-      - name: download localcse and run
+      - name: download-cse
+        uses: actions/download-artifact@v3
+        with:
+          name: local-cse
+      - name: start cse
         run: |
           export ROOT_PATH=$(pwd)
-          bash ./sermant-integration-tests/scripts/downloadAndStartCse.sh
+          bash ./sermant-integration-tests/scripts/startCse.sh
+      - name: cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: package agent
         run: mvn package -DskipTests -Pagent --file pom.xml
       - name: package spring zk config

--- a/sermant-integration-tests/scripts/downloadCse.sh
+++ b/sermant-integration-tests/scripts/downloadCse.sh
@@ -16,25 +16,28 @@
 #
 
 #!/bin/bash
-tryTimes=3
-cseAddress=https://cse-bucket.obs.cn-north-1.myhuaweicloud.com/LocalCSE/Local-CSE-2.1.3-linux-amd64.zip
-echo "root path: ${ROOT_PATH}"
-for ((i=1; i<=${tryTimes};i++))
-do
-  echo "try download cse at $i time"
-  wget ${cseAddress} -O ${ROOT_PATH}/Local-CSE-2.1.3-linux-amd64.zip
-  if [ $? == 0 ];then
-    break
+downloadCse(){
+  tryTimes=3
+  cseAddress=https://cse-bucket.obs.cn-north-1.myhuaweicloud.com/LocalCSE/Local-CSE-2.1.3-linux-amd64.zip
+  echo "root path: ${ROOT_PATH}"
+  for ((i=1; i<=${tryTimes};i++))
+  do
+    echo "try download cse at $i time"
+    wget ${cseAddress} -O ${ROOT_PATH}/Local-CSE-2.1.3-linux-amd64.zip
+    if [ $? == 0 ];then
+      break
+    fi
+    sleep 3
+  done
+  ls -l
+  if [ -f ${ROOT_PATH}/Local-CSE-2.1.3-linux-amd64.zip ];then
+    echo "download cse success"
+  else
+    exit 1
   fi
-  sleep 3
-done
-ls -l
-if [ -f ${ROOT_PATH}/Local-CSE-2.1.3-linux-amd64.zip ];then
-  echo "download cse success, then start cse"
-  unzip ${ROOT_PATH}/Local-CSE-2.1.3-linux-amd64.zip -d ${ROOT_PATH}/cse
-  sh ${ROOT_PATH}/cse/start.sh &
-else
-  exit 1
-fi
+}
+
+downloadCse
+
 
 

--- a/sermant-integration-tests/scripts/startCse.sh
+++ b/sermant-integration-tests/scripts/startCse.sh
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +15,15 @@
 #
 #
 
-com.huawei.dynamic.config.declarers.SpringFactoriesDeclarer
-com.huawei.dynamic.config.declarers.ZookeeperLocatorDeclarer
-com.huawei.dynamic.config.declarers.MutableSourceDeclarer
+#!/bin/bash
+startCse(){
+  if [ -f ${ROOT_PATH}/Local-CSE-2.1.3-linux-amd64.zip ];then
+    echo "==========start cse============"
+    unzip ${ROOT_PATH}/Local-CSE-2.1.3-linux-amd64.zip -d ${ROOT_PATH}/cse
+    sh ${ROOT_PATH}/cse/start.sh &
+  else
+    echo "==========can not find cse software============"
+    exit 2
+  fi
+}
+startCse

--- a/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/main/java/com/huawei/dynamic/config/declarers/MutableSourceDeclarer.java
+++ b/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/main/java/com/huawei/dynamic/config/declarers/MutableSourceDeclarer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.huawei.dynamic.config.declarers;
+
+import com.huawei.dynamic.config.interceptors.MutableSourceInterceptor;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+
+/**
+ * 针对addFirst方法拦截, 当用户在配置中心下发配置, 动态关闭原生配置中心, 此拦截点开始拦截添加原生配置中心配置源, 阻止配置生效
+ * 生效见{@link com.huawei.dynamic.config.source.OriginConfigCenterDisableListener}添加禁止配置源
+ *
+ * @author zhouss
+ * @since 2022-04-08
+ */
+public class MutableSourceDeclarer extends AbstractPluginDeclarer {
+    private static final String ENHANCE_CLASS =
+            "org.springframework.core.env.MutablePropertySources";
+
+    private static final String INTERCEPTOR_CLASS = MutableSourceInterceptor.class.getCanonicalName();
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.nameEquals(ENHANCE_CLASS);
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{
+                InterceptDeclarer.build(MethodMatcher.nameEquals("addFirst").and(MethodMatcher.paramCountEquals(1)),
+                        INTERCEPTOR_CLASS)
+        };
+    }
+}

--- a/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/main/java/com/huawei/dynamic/config/interceptors/DynamicConfigSwitchSupport.java
+++ b/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/main/java/com/huawei/dynamic/config/interceptors/DynamicConfigSwitchSupport.java
@@ -17,7 +17,9 @@
 
 package com.huawei.dynamic.config.interceptors;
 
+import com.huawei.dynamic.config.ConfigHolder;
 import com.huawei.dynamic.config.DynamicConfiguration;
+import com.huawei.dynamic.config.source.OriginConfigDisableSource;
 
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.plugin.agent.interceptor.Interceptor;
@@ -37,6 +39,19 @@ public class DynamicConfigSwitchSupport implements Interceptor {
      */
     public DynamicConfigSwitchSupport() {
         dynamicConfiguration = PluginConfigManager.getPluginConfig(DynamicConfiguration.class);
+    }
+
+    /**
+     * 原配置中心是否已下发动态关闭
+     *
+     * @return 是否关闭
+     */
+    protected boolean isDynamicClosed() {
+        final Object config = ConfigHolder.INSTANCE.getConfig(OriginConfigDisableSource.ZK_CONFIG_CENTER_ENABLED);
+        if (config == null) {
+            return false;
+        }
+        return !Boolean.parseBoolean(config.toString());
     }
 
     @Override

--- a/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/main/java/com/huawei/dynamic/config/interceptors/MutableSourceInterceptor.java
+++ b/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/main/java/com/huawei/dynamic/config/interceptors/MutableSourceInterceptor.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.huawei.dynamic.config.interceptors;
+
+import com.huawei.dynamic.config.DynamicConfiguration;
+
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
+
+import org.springframework.cloud.bootstrap.config.BootstrapPropertySource;
+
+import java.util.Locale;
+import java.util.logging.Logger;
+
+/**
+ * 针对addFirst方法拦截, 当用户在配置中心下发配置, 动态关闭原生配置中心, 此拦截点开始拦截添加原生配置中心配置源, 阻止配置生效
+ * 生效见{@link com.huawei.dynamic.config.source.OriginConfigCenterDisableListener}添加禁止配置源
+ *
+ * @author zhouss
+ * @since 2022-04-08
+ */
+public class MutableSourceInterceptor extends DynamicConfigSwitchSupport {
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
+    private static final String ZOOKEEPER_SOURCE = "org.springframework.cloud.zookeeper.config.ZookeeperPropertySource";
+
+    private static final String NACOS_SOURCE = "com.alibaba.cloud.nacos.client.NacosPropertySource";
+
+    private static final String BOOTSTRAP_SOURCE = "org.springframework.cloud.bootstrap.config.BootstrapPropertySource";
+
+    private final DynamicConfiguration configuration;
+
+    /**
+     * 构造器
+     */
+    public MutableSourceInterceptor() {
+        configuration = PluginConfigManager.getPluginConfig(DynamicConfiguration.class);
+    }
+
+    @Override
+    public ExecuteContext doBefore(ExecuteContext context) {
+        if (!configuration.isEnableOriginConfigCenter() || !isDynamicClosed()) {
+            return context;
+        }
+        final Object source = context.getArguments()[0];
+        if (!BOOTSTRAP_SOURCE.equals(source.getClass().getName())) {
+            return context;
+        }
+        BootstrapPropertySource<?> bootstrapPropertySource = (BootstrapPropertySource<?>) source;
+        if (isTargetSource(bootstrapPropertySource.getDelegate())) {
+            LOGGER.info(String.format(Locale.ENGLISH,
+                    "Ignored source [%s] because of origin config center's has been closed!", source));
+            context.skip(null);
+        }
+        return context;
+    }
+
+    private boolean isTargetSource(Object source) {
+        final String name = source.getClass().getName();
+        return ZOOKEEPER_SOURCE.equals(name) || NACOS_SOURCE.equals(name);
+    }
+}

--- a/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/main/java/com/huawei/dynamic/config/interceptors/ZookeeperLocatorInterceptor.java
+++ b/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/main/java/com/huawei/dynamic/config/interceptors/ZookeeperLocatorInterceptor.java
@@ -17,14 +17,10 @@
 
 package com.huawei.dynamic.config.interceptors;
 
-import com.huawei.dynamic.config.ConfigHolder;
 import com.huawei.dynamic.config.DynamicConfiguration;
-import com.huawei.dynamic.config.source.OriginConfigDisableSource;
 
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
-
-import org.springframework.core.env.CompositePropertySource;
 
 /**
  * 拦截loadFactories注入自定义配置源
@@ -45,21 +41,8 @@ public class ZookeeperLocatorInterceptor extends DynamicConfigSwitchSupport {
     @Override
     public ExecuteContext doBefore(ExecuteContext context) {
         if (!configuration.isEnableOriginConfigCenter() || isDynamicClosed()) {
-            context.skip(new CompositePropertySource("Empty"));
+            context.skip(null);
         }
         return context;
-    }
-
-    /**
-     * 原配置中心是否已下发动态关闭
-     *
-     * @return 是否关闭
-     */
-    private boolean isDynamicClosed() {
-        final Object config = ConfigHolder.INSTANCE.getConfig(OriginConfigDisableSource.ZK_CONFIG_CENTER_ENABLED);
-        if (config == null) {
-            return false;
-        }
-        return !Boolean.parseBoolean(config.toString());
     }
 }

--- a/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/main/java/com/huawei/dynamic/config/source/OriginConfigCenterDisableListener.java
+++ b/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/main/java/com/huawei/dynamic/config/source/OriginConfigCenterDisableListener.java
@@ -28,7 +28,9 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
+import org.springframework.core.env.PropertySource;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -81,7 +83,25 @@ public class OriginConfigCenterDisableListener implements BeanFactoryAware {
                             closer.type()));
                 }
             }
+            tryAddDynamicSourceToFirst(environment);
         });
+    }
+
+    private void tryAddDynamicSourceToFirst(Environment curEnv) {
+        if (!(curEnv instanceof ConfigurableEnvironment)) {
+            return;
+        }
+        ConfigurableEnvironment configurableEnvironment = (ConfigurableEnvironment) curEnv;
+        addToFirst(configurableEnvironment, DynamicConstants.DISABLE_CONFIG_SOURCE_NAME);
+        addToFirst(configurableEnvironment, DynamicConstants.PROPERTY_NAME);
+    }
+
+    private void addToFirst(ConfigurableEnvironment configurableEnvironment, String name) {
+        final PropertySource<?> propertySource = configurableEnvironment.getPropertySources().get(name);
+        if (propertySource != null) {
+            configurableEnvironment.getPropertySources().remove(name);
+            configurableEnvironment.getPropertySources().addFirst(propertySource);
+        }
     }
 
     private void disableConfigCenter() {


### PR DESCRIPTION
【issue号/问题单号/需求单号】#670

【修改内容】
- 修复动态配置插件偶尔出现自动化测试失败的问题，主要基于spring环境变量优先级进行调整，当动态关闭配置中心时，动态提升sermant自身配置源优先级
- 自动化测试优化，maven依赖缓存，使用共享cse

【用例描述】暂无用例

【自测情况】本地测试通过；基于自动化测试action，多次测试暂未发现问题

【影响范围】动态配置能力
