### PR TITLE
【doc】插件interceptor和service单元测试模版

### DIFF
--- a/sermant-example/demo-plugin/pom.xml
+++ b/sermant-example/demo-plugin/pom.xml
@@ -30,6 +30,27 @@
             <version>3.1.0</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.huaweicloud.sermant</groupId>
+            <artifactId>demo-application</artifactId>
+            <version>1.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/sermant-example/demo-plugin/src/main/java/com/huawei/example/demo/service/DemoSimpleService.java
+++ b/sermant-example/demo-plugin/src/main/java/com/huawei/example/demo/service/DemoSimpleService.java
@@ -17,7 +17,9 @@
 package com.huawei.example.demo.service;
 
 import com.huawei.example.demo.common.DemoLogger;
+import com.huawei.example.demo.config.DemoConfig;
 
+import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
 import com.huaweicloud.sermant.core.plugin.service.PluginService;
 import com.huaweicloud.sermant.core.plugin.service.PluginServiceManager;
 
@@ -29,9 +31,20 @@ import com.huaweicloud.sermant.core.plugin.service.PluginServiceManager;
  * @since 2021-10-25
  */
 public class DemoSimpleService implements PluginService {
+
+    private final DemoConfig config;
+
+    /**
+     * 构造方法
+     */
+    public DemoSimpleService() {
+        config = PluginConfigManager.getPluginConfig(DemoConfig.class);
+    }
+
     @Override
     public void start() {
         DemoLogger.println("[DemoSimpleService]-start");
+        DemoLogger.println(config.toString());
     }
 
     @Override

--- a/sermant-example/demo-plugin/src/test/java/com/huawei/example/demo/interceptor/DemoInterceptorTest.java
+++ b/sermant-example/demo-plugin/src/test/java/com/huawei/example/demo/interceptor/DemoInterceptorTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.example.demo.interceptor;
+
+import com.huawei.example.demo.service.DemoNameService;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 拦截器单元测试示例模版
+ *
+ * @author lilai
+ * @version 1.0.0
+ * @since 2022-08-25
+ */
+public class DemoInterceptorTest {
+    /**
+     * 被测试的拦截器
+     */
+    private DemoMemberInterceptor interceptor;
+
+    /**
+     * 被增强的对象
+     */
+    private Object object;
+
+    /**
+     * 被增强的方法
+     */
+    private Method method;
+
+    /**
+     * 被增强的方法入参
+     */
+    private Object[] arguments;
+
+    /**
+     * 额外的静态属性
+     */
+    private Map<String, Object> extStaticFields;
+
+    /**
+     * 额外的成员属性
+     */
+    private Map<String, Object> extMemberFields;
+
+    /**
+     * 测试类构造方法，初始化相关参数
+     */
+    public DemoInterceptorTest() throws NoSuchMethodException {
+        this.interceptor = new DemoMemberInterceptor();
+        this.object = new Object();
+        this.method = DemoNameService.class.getMethod("configFunc");
+        this.arguments = new Object[1];
+        this.arguments[0] = "test";
+        this.extStaticFields = new HashMap<>();
+        this.extMemberFields = new HashMap<>();
+    }
+
+    /**
+     * 构建插件执行上下文，以成员方法为例
+     */
+    private ExecuteContext buildContext(Object object, Method method, Object[] arguments,
+                                        Map<String, Object> extStaticFields, Map<String, Object> extMemberFields) {
+        return ExecuteContext.forMemberMethod(object, method, arguments, extStaticFields, extMemberFields);
+    }
+
+    /**
+     * 测试拦截器before方法
+     */
+    @Test
+    public void testBefore() throws Exception {
+        ExecuteContext context = buildContext(object, method, arguments, extStaticFields, extMemberFields);
+        interceptor.before(context);
+
+        // 根据拦截器before方法实现的功能来验证增强是否生效，此仅处为示例
+        Assert.assertEquals("test", context.getArguments()[0]);
+    }
+
+    /**
+     * 测试拦截器after方法
+     */
+    @Test
+    public void testAfter() throws Exception {
+        ExecuteContext context = buildContext(object, method, arguments, null, null);
+        interceptor.after(context);
+
+        // 根据拦截器after方法实现的功能来验证增强是否生效，此处仅为示例
+        Assert.assertEquals("test", context.getArguments()[0]);
+    }
+
+    /**
+     * 测试拦截器onThrow方法
+     */
+    @Test
+    public void testOnThrow() throws Exception {
+        ExecuteContext context = buildContext(object, method, arguments, null, null);
+        interceptor.onThrow(context);
+
+        // 根据拦截器onThrow方法实现的功能来验证增强是否生效，此处为仅示例
+        Assert.assertEquals("test", context.getArguments()[0]);
+    }
+}

--- a/sermant-example/demo-plugin/src/test/java/com/huawei/example/demo/service/DemoServiceTest.java
+++ b/sermant-example/demo-plugin/src/test/java/com/huawei/example/demo/service/DemoServiceTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.example.demo.service;
+
+import com.huawei.example.demo.config.DemoConfig;
+import com.huawei.example.demo.config.DemoType;
+
+import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Field;
+
+/**
+ * 插件服务单元测试示例模版
+ *
+ * @author lilai
+ * @version 1.0.0
+ * @since 2022-08-25
+ */
+public class DemoServiceTest {
+    private DemoSimpleService service;
+
+    private DemoConfig config;
+
+    private MockedStatic<PluginConfigManager> mockPluginConfigManager;
+
+    /**
+     * UT执行前
+     * 对service中的PluginConfigManager.getPluginConfig()方法进行mock
+     */
+    @Before
+    public void setUp() {
+        config = new DemoConfig();
+        mockPluginConfigManager = Mockito.mockStatic(PluginConfigManager.class);
+        mockPluginConfigManager.when(() -> PluginConfigManager.getPluginConfig(DemoConfig.class)).thenReturn(config);
+        this.service = new DemoSimpleService();
+    }
+
+    /**
+     * UT执行后
+     * 释放mock对象
+     */
+    @After
+    public void tearDown() {
+        mockPluginConfigManager.close();
+    }
+
+    /**
+     * 对config的具体内容赋值，此处为示例
+     */
+    public void setConfig() {
+        config.setIntField(123456);
+        config.setStrField("test");
+        config.setEnumType(DemoType.DEMO);
+    }
+
+
+    /**
+     * 测试服务启动方法
+     */
+    @Test
+    public void testStart() throws NoSuchFieldException, IllegalAccessException {
+        setConfig();
+        service.start();
+
+        // 根据插件服务start方法实现的功能来验证服务能力，此处仅为示例，验证config是否正确
+        Field configField = service.getClass().getDeclaredField("config");
+        configField.setAccessible(true);
+        int exactInt = ((DemoConfig) configField.get(service)).getIntField();
+        String exactStr = ((DemoConfig) configField.get(service)).getStrField();
+
+        Assert.assertEquals(123456, exactInt);
+        Assert.assertEquals("test", exactStr);
+    }
+
+    /**
+     * 测试服务关闭方法
+     */
+    @Test
+    public void testStop() {
+        service.stop();
+
+        // 根据插件服务stop方法实现的功能来验证服务能力，此处仅为示例
+        Assert.assertTrue(true);
+    }
+
+    /**
+     * 测试public方法passiveFunc()
+     */
+    @Test
+    public void testPassiveFunc() {
+        service.passiveFunc();
+
+        // 根据插件服务passiveFunc方法实现的功能来验证服务能力，此处仅为示例
+        Assert.assertTrue(true);
+    }
+}


### PR DESCRIPTION
【issue号/问题单号/需求单号】#674

【修改内容】新增interceptor(插件拦截器)和service(插件服务，包含获取插件配置)单元测试模版。

各位在开发新插件时，需按照模板要求编写interceptor和service的单元测试，以保证插件基本能力和代码质量。

【用例描述】无需用例

【自测情况】UT测试通过

【影响范围】插件拦截器和插件服务相关UT