### PR TITLE
【fix】修复路由插件的bug

### DIFF
--- a/sermant-plugins/sermant-router/dubbo-router-service/src/main/java/com/huaweicloud/sermant/router/dubbo/strategy/instance/MismatchInstanceStrategy.java
+++ b/sermant-plugins/sermant-router/dubbo-router-service/src/main/java/com/huaweicloud/sermant/router/dubbo/strategy/instance/MismatchInstanceStrategy.java
@@ -16,14 +16,11 @@
 
 package com.huaweicloud.sermant.router.dubbo.strategy.instance;
 
-import com.huaweicloud.sermant.core.utils.StringUtils;
 import com.huaweicloud.sermant.router.common.constants.RouterConstant;
 import com.huaweicloud.sermant.router.config.strategy.AbstractInstanceStrategy;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Function;
 
 /**
@@ -45,7 +42,6 @@ public class MismatchInstanceStrategy extends AbstractInstanceStrategy<Object> {
         Function<Object, Map<String, String>> mapper) {
         // 由于由于mismatch里面的标签已经匹配过了且没有匹配上，所以要剔除掉，不能参与负载均衡，否则会导致流量比例不正确（会偏高）
         Map<String, String> metaData = getMetadata(invoker, mapper);
-
         for (Map<String, String> mismatchTag : tags) {
             for (Map.Entry<String, String> entry : mismatchTag.entrySet()) {
                 String value = entry.getValue();
@@ -53,7 +49,7 @@ public class MismatchInstanceStrategy extends AbstractInstanceStrategy<Object> {
                     continue;
                 }
                 String key = VERSION_KEY.equals(entry.getKey()) ? RouterConstant.VERSION_KEY
-                        : RouterConstant.PARAMETERS_KEY_PREFIX + entry.getKey();
+                    : RouterConstant.PARAMETERS_KEY_PREFIX + entry.getKey();
                 if (value.equals(metaData.get(key))) {
                     return false;
                 }

--- a/sermant-plugins/sermant-router/router-config-common/src/main/java/com/huaweicloud/sermant/router/config/label/entity/RouterConfiguration.java
+++ b/sermant-plugins/sermant-router/router-config-common/src/main/java/com/huaweicloud/sermant/router/config/label/entity/RouterConfiguration.java
@@ -29,7 +29,6 @@ import java.util.concurrent.ConcurrentHashMap;
  * @since 2021-10-27
  */
 public class RouterConfiguration {
-
     /**
      * 标签规则,key为应用名，value为规则
      */

--- a/sermant-plugins/sermant-router/router-config-common/src/main/java/com/huaweicloud/sermant/router/config/label/entity/ValueMatchDeserializer.java
+++ b/sermant-plugins/sermant-router/router-config-common/src/main/java/com/huaweicloud/sermant/router/config/label/entity/ValueMatchDeserializer.java
@@ -111,8 +111,8 @@ public class ValueMatchDeserializer implements ObjectDeserializer {
         MatchStrategy matchStrategy;
         try {
             matchStrategy = MatchStrategy.valueOf(fieldName.toUpperCase(Locale.ROOT));
-        } catch (IllegalArgumentException e1) {
-            LOGGER.warning("Cannot find the match strategy " + fieldName);
+        } catch (IllegalArgumentException ignored) {
+            // 不存在该策略，忽略
             return;
         }
         List<String> values = new ArrayList<>();

--- a/sermant-plugins/sermant-router/router-config-common/src/main/java/com/huaweicloud/sermant/router/config/utils/RuleUtils.java
+++ b/sermant-plugins/sermant-router/router-config-common/src/main/java/com/huaweicloud/sermant/router/config/utils/RuleUtils.java
@@ -24,8 +24,8 @@ import com.huaweicloud.sermant.router.config.label.entity.Route;
 import com.huaweicloud.sermant.router.config.label.entity.RouterConfiguration;
 import com.huaweicloud.sermant.router.config.label.entity.Rule;
 
-import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -58,12 +58,12 @@ public class RuleUtils {
      *
      * @param configuration 路由配置
      * @param targetService 目标服务
-     * @param path          dubbo接口名/url路径
-     * @param serviceName   本服务服务名
+     * @param path dubbo接口名/url路径
+     * @param serviceName 本服务服务名
      * @return 目标规则
      */
     public static List<Rule> getRules(RouterConfiguration configuration, String targetService, String path,
-                                      String serviceName) {
+        String serviceName) {
         if (RouterConfiguration.isInValid(configuration)) {
             return Collections.emptyList();
         }
@@ -133,7 +133,7 @@ public class RuleUtils {
      * 更新header key
      *
      * @param serviceName 服务名
-     * @param rules       路由规则
+     * @param rules 路由规则
      */
     public static void updateHeaderKeys(String serviceName, List<Rule> rules) {
         if (CollectionUtils.isEmpty(rules)) {
@@ -212,14 +212,16 @@ public class RuleUtils {
     }
 
     /**
-     * 将headers规则写入attachemnts
+     * 将headers规则写入attachments
      *
      * @param match headers匹配规则
      */
     public static void setAttachmentsByHeaders(Match match) {
-        if (match == null) {
+        if (match == null || !CollectionUtils.isEmpty(match.getAttachments())) {
             return;
         }
+
+        // attachments兼容headers
         match.setAttachments(match.getHeaders());
     }
 
@@ -295,8 +297,8 @@ public class RuleUtils {
 
     private static boolean isInvalidMatchRule(MatchRule matchRule) {
         return matchRule == null || matchRule.getValueMatch() == null
-                || CollectionUtils.isEmpty(matchRule.getValueMatch().getValues())
-                || matchRule.getValueMatch().getMatchStrategy() == null;
+            || CollectionUtils.isEmpty(matchRule.getValueMatch().getValues())
+            || matchRule.getValueMatch().getMatchStrategy() == null;
     }
 
     private static boolean isInvalidRoute(Route route) {
@@ -318,7 +320,7 @@ public class RuleUtils {
          * 构造方法
          *
          * @param match 是否匹配
-         * @param tags  目标路由
+         * @param tags 目标路由
          */
         public RouteResult(boolean match, List<Map<String, String>> tags) {
             this.match = match;


### PR DESCRIPTION
【issue号/问题单号/需求单号】 #684 

【修改内容】1.去掉解析路由策略的警告日志；2.修复attachments被覆盖的问题

【用例描述】暂无用例

【自测情况】
- 本地测试，配置路由规则时，配置不存在的值匹配策略，不再打印日志;
- 同时配置headers和attachments，attachments不会被覆盖

【影响范围】路由插件